### PR TITLE
Re-instate `final` visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 2.0.0 - TBD
+## 2.0.0 - 2015-09-17
 
 ### Added
 
-- Nothing.
+- The following classes were marked `final` (per their original implementation
+  in zend-stdlib):
+  - `Zend\Hydrator\NamingStrategy\IdentityNamingStrategy`
+  - `Zend\Hydrator\NamingStrategy\ArrayMapNamingStrategy`
+  - `Zend\Hydrator\NamingStrategy\CompositeNamingStrategy`
+  - `Zend\Hydrator\Strategy\ExplodeStrategy`
+  - `Zend\Hydrator\Strategy\StrategyChain`
+  - `Zend\Hydrator\Strategy\DateTimeFormatterStrategy`
+  - `Zend\Hydrator\Strategy\BooleanStrategy`
 
 ### Deprecated
 

--- a/src/NamingStrategy/ArrayMapNamingStrategy.php
+++ b/src/NamingStrategy/ArrayMapNamingStrategy.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Hydrator\NamingStrategy;
 
-class ArrayMapNamingStrategy implements NamingStrategyInterface
+final class ArrayMapNamingStrategy implements NamingStrategyInterface
 {
     /**
      * @var string[]

--- a/src/NamingStrategy/CompositeNamingStrategy.php
+++ b/src/NamingStrategy/CompositeNamingStrategy.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Hydrator\NamingStrategy;
 
-class CompositeNamingStrategy implements NamingStrategyInterface
+final class CompositeNamingStrategy implements NamingStrategyInterface
 {
     /**
      * @var array

--- a/src/NamingStrategy/IdentityNamingStrategy.php
+++ b/src/NamingStrategy/IdentityNamingStrategy.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Hydrator\NamingStrategy;
 
-class IdentityNamingStrategy implements NamingStrategyInterface
+final class IdentityNamingStrategy implements NamingStrategyInterface
 {
     /**
      * {@inheritDoc}

--- a/src/Strategy/BooleanStrategy.php
+++ b/src/Strategy/BooleanStrategy.php
@@ -14,7 +14,7 @@ use Zend\Hydrator\Exception\InvalidArgumentException;
 /**
  * This Strategy extracts and hydrates int and string values to Boolean values
  */
-class BooleanStrategy implements StrategyInterface
+final class BooleanStrategy implements StrategyInterface
 {
     /**
      * @var int|string

--- a/src/Strategy/DateTimeFormatterStrategy.php
+++ b/src/Strategy/DateTimeFormatterStrategy.php
@@ -12,7 +12,7 @@ namespace Zend\Hydrator\Strategy;
 use DateTime;
 use DateTimeZone;
 
-class DateTimeFormatterStrategy implements StrategyInterface
+final class DateTimeFormatterStrategy implements StrategyInterface
 {
     /**
      * @var string

--- a/src/Strategy/ExplodeStrategy.php
+++ b/src/Strategy/ExplodeStrategy.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Hydrator\Strategy;
 
-class ExplodeStrategy implements StrategyInterface
+final class ExplodeStrategy implements StrategyInterface
 {
     /**
      * @var string

--- a/src/Strategy/StrategyChain.php
+++ b/src/Strategy/StrategyChain.php
@@ -12,7 +12,7 @@ namespace Zend\Hydrator\Strategy;
 use Traversable;
 use Zend\Stdlib\ArrayUtils;
 
-class StrategyChain implements StrategyInterface
+final class StrategyChain implements StrategyInterface
 {
     /**
      * Strategy chain for extraction


### PR DESCRIPTION
This patch completes #2, marking classes `final` as they were originally in zend-stdlib.