### PR TITLE
Finalize forwards-compatibility support for zend-hydrator v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
     - php: 5.5
       env:
         - SERVICE_MANAGER_VERSION="^2.7.3"
-        - EVENT_MANAGER_VERSION="^2.6.2"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
@@ -39,17 +38,14 @@ matrix:
     - php: 5.6
       env:
         - SERVICE_MANAGER_VERSION="^2.7.3"
-        - EVENT_MANAGER_VERSION="^2.6.2"
     - php: 7
     - php: 7
       env:
         - SERVICE_MANAGER_VERSION="^2.7.3"
-        - EVENT_MANAGER_VERSION="^2.6.2"
     - php: hhvm
     - php: hhvm
       env:
         - SERVICE_MANAGER_VERSION="^2.7.3"
-        - EVENT_MANAGER_VERSION="^2.6.2"
   allow_failures:
     - php: 7
 
@@ -61,8 +57,6 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
-  - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
-  - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^3.0" ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,20 @@ matrix:
   include:
     - php: 5.5
       env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
         - EXECUTE_CS_CHECK=true
     - php: 5.6
       env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
         - EXECUTE_TEST_COVERALLS=true
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
     - php: 7
-    - php: hhvm 
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
+    - php: hhvm
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
   allow_failures:
     - php: 7
 
@@ -45,6 +51,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,20 +26,30 @@ matrix:
   include:
     - php: 5.5
       env:
-        - SERVICE_MANAGER_VERSION="^2.7.3"
         - EXECUTE_CS_CHECK=true
-    - php: 5.6
+    - php: 5.5
       env:
         - SERVICE_MANAGER_VERSION="^2.7.3"
+        - EVENT_MANAGER_VERSION="^2.6.2"
+    - php: 5.6
+      env:
         - EXECUTE_TEST_COVERALLS=true
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
+        - EVENT_MANAGER_VERSION="^2.6.2"
+    - php: 7
     - php: 7
       env:
         - SERVICE_MANAGER_VERSION="^2.7.3"
+        - EVENT_MANAGER_VERSION="^2.6.2"
+    - php: hhvm
     - php: hhvm
       env:
         - SERVICE_MANAGER_VERSION="^2.7.3"
+        - EVENT_MANAGER_VERSION="^2.6.2"
   allow_failures:
     - php: 7
 
@@ -51,8 +61,10 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
+  - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^3.0" ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "zendframework/zend-stdlib": "^2.7 || ^3.0"
+        "zendframework/zend-stdlib": "^3.0"
     },
     "require-dev": {
-        "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+        "zendframework/zend-eventmanager": "^3.0",
         "zendframework/zend-inputfilter": "^2.6",
         "zendframework/zend-serializer": "^2.6.1",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
+            "dev-release-1.0": "1.0-dev",
             "dev-master": "2.0-dev",
             "dev-develop": "2.1-dev"
         }

--- a/composer.json
+++ b/composer.json
@@ -13,23 +13,23 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "dev-develop as 2.5.1"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
-        "zendframework/zend-inputfilter": "dev-develop as 2.6.0",
-        "zendframework/zend-serializer": "dev-develop",
+        "zendframework/zend-inputfilter": "^2.6",
+        "zendframework/zend-serializer": "^2.6.1",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-        "zendframework/zend-filter": "^2.6.0",
+        "zendframework/zend-filter": "^2.6",
         "phpunit/PHPUnit": "~4.0",
         "squizlabs/php_codesniffer": "^2.0@dev"
     },
     "suggest": {
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0, to support aggregate hydrator usage",
-        "zendframework/zend-serializer": "^2.5.1, to use the SerializableStrategy",
-        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0, to support hydrator plugin manager usage",
-        "zendframework/zend-filter": "^2.6.0, to support naming strategy hydrator usage"
+        "zendframework/zend-serializer": "^2.6.1, to use the SerializableStrategy",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3, to support hydrator plugin manager usage",
+        "zendframework/zend-filter": "^2.6, to support naming strategy hydrator usage"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -14,22 +14,22 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "^2.5.1"
+        "zendframework/zend-stdlib": "dev-develop as 2.5.1"
     },
     "require-dev": {
-        "zendframework/zend-eventmanager": "^2.5.1",
-        "zendframework/zend-inputfilter": "^2.5.1",
-        "zendframework/zend-serializer": "^2.5.1",
-        "zendframework/zend-servicemanager": "^2.5.1",
-        "zendframework/zend-filter": "^2.5.1",
+        "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+        "zendframework/zend-inputfilter": "dev-develop as 2.6.0",
+        "zendframework/zend-serializer": "dev-develop",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+        "zendframework/zend-filter": "^2.6.0",
         "phpunit/PHPUnit": "~4.0",
         "squizlabs/php_codesniffer": "^2.0@dev"
     },
     "suggest": {
-        "zendframework/zend-eventmanager": "^2.5.1, to support aggregate hydrator usage",
+        "zendframework/zend-eventmanager": "^2.6.2 || ^3.0, to support aggregate hydrator usage",
         "zendframework/zend-serializer": "^2.5.1, to use the SerializableStrategy",
-        "zendframework/zend-servicemanager": "^2.5.1, to support hydrator plugin manager usage",
-        "zendframework/zend-filter": "^2.5.1, to support naming strategy hydrator usage"
+        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0, to support hydrator plugin manager usage",
+        "zendframework/zend-filter": "^2.6.0, to support naming strategy hydrator usage"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Aggregate/AggregateHydrator.php
+++ b/src/Aggregate/AggregateHydrator.php
@@ -34,7 +34,8 @@ class AggregateHydrator implements HydratorInterface, EventManagerAwareInterface
      */
     public function add(HydratorInterface $hydrator, $priority = self::DEFAULT_PRIORITY)
     {
-        $this->getEventManager()->attachAggregate(new HydratorListener($hydrator), $priority);
+        $listener = new HydratorListener($hydrator);
+        $listener->attach($this->getEventManager(), $priority);
     }
 
     /**
@@ -44,7 +45,7 @@ class AggregateHydrator implements HydratorInterface, EventManagerAwareInterface
     {
         $event = new ExtractEvent($this, $object);
 
-        $this->getEventManager()->trigger($event);
+        $this->getEventManager()->triggerEvent($event);
 
         return $event->getExtractedData();
     }
@@ -56,7 +57,7 @@ class AggregateHydrator implements HydratorInterface, EventManagerAwareInterface
     {
         $event = new HydrateEvent($this, $object, $data);
 
-        $this->getEventManager()->trigger($event);
+        $this->getEventManager()->triggerEvent($event);
 
         return $event->getHydratedObject();
     }

--- a/src/DelegatingHydrator.php
+++ b/src/DelegatingHydrator.php
@@ -9,21 +9,21 @@
 
 namespace Zend\Hydrator;
 
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Interop\Container\ContainerInterface;
 
 class DelegatingHydrator implements HydratorInterface
 {
     /**
-     * @var ServiceLocatorInterface
+     * @var ContainerInterface
      */
     protected $hydrators;
 
     /**
      * Constructor
      *
-     * @param ServiceLocatorInterface $hydrators
+     * @param ContainerInterface $hydrators
      */
-    public function __construct(ServiceLocatorInterface $hydrators)
+    public function __construct(ContainerInterface $hydrators)
     {
         $this->hydrators = $hydrators;
     }

--- a/src/DelegatingHydratorFactory.php
+++ b/src/DelegatingHydratorFactory.php
@@ -62,7 +62,7 @@ class DelegatingHydratorFactory implements FactoryInterface
         if ($container->has('HydratorManager')) {
             return $container->get('HydratorManager');
         }
-        
+
         // Fallback: create one
         return new HydratorPluginManager($container);
     }

--- a/src/DelegatingHydratorFactory.php
+++ b/src/DelegatingHydratorFactory.php
@@ -36,8 +36,34 @@ class DelegatingHydratorFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        // Assume that this factory is registered with the HydratorManager,
-        // and just pass it directly on.
+        $container = $this->marshalHydratorPluginManager($container);
         return new DelegatingHydrator($container);
+    }
+
+    /**
+     * Locate and return a HydratorPluginManager instance.
+     *
+     * @param ContainerInterface $container
+     * @return HydratorPluginManager
+     */
+    private function marshalHydratorPluginManager(ContainerInterface $container)
+    {
+        // Already one? Return it.
+        if ($container instanceof HydratorPluginManager) {
+            return $container;
+        }
+
+        // As typically registered with v3 (FQCN)
+        if ($container->has(HydratorPluginManager::class)) {
+            return $container->get(HydratorPluginManager::class);
+        }
+
+        // As registered by zend-mvc
+        if ($container->has('HydratorManager')) {
+            return $container->get('HydratorManager');
+        }
+        
+        // Fallback: create one
+        return new HydratorPluginManager($container);
     }
 }

--- a/src/DelegatingHydratorFactory.php
+++ b/src/DelegatingHydratorFactory.php
@@ -9,21 +9,35 @@
 
 namespace Zend\Hydrator;
 
+use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class DelegatingHydratorFactory implements FactoryInterface
 {
     /**
-     * Creates DelegatingHydrator
+     * Creates DelegatingHydrator (v2)
      *
      * @param  ServiceLocatorInterface $serviceLocator
      * @return DelegatingHydrator
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
+        return $this($serviceLocator, '');
+    }
+
+    /**
+     * Creates DelegatingHydrator (v3)
+     *
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param array|null $options
+     * @return DelegatingHydrator
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
         // Assume that this factory is registered with the HydratorManager,
         // and just pass it directly on.
-        return new DelegatingHydrator($serviceLocator);
+        return new DelegatingHydrator($container);
     }
 }

--- a/src/HydratorPluginManager.php
+++ b/src/HydratorPluginManager.php
@@ -10,6 +10,8 @@
 namespace Zend\Hydrator;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
+use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
  * Plugin manager implementation for hydrators.
@@ -19,31 +21,25 @@ use Zend\ServiceManager\AbstractPluginManager;
 class HydratorPluginManager extends AbstractPluginManager
 {
     /**
-     * Whether or not to share by default
-     *
-     * @var bool
-     */
-    protected $shareByDefault = false;
-
-    /**
      * Default aliases
      *
      * @var array
      */
     protected $aliases = [
-        'delegatinghydrator' => 'Zend\Hydrator\DelegatingHydrator',
-    ];
-
-    /**
-     * Default set of adapters
-     *
-     * @var array
-     */
-    protected $invokableClasses = [
-        'arrayserializable' => 'Zend\Hydrator\ArraySerializable',
-        'classmethods'      => 'Zend\Hydrator\ClassMethods',
-        'objectproperty'    => 'Zend\Hydrator\ObjectProperty',
-        'reflection'        => 'Zend\Hydrator\Reflection'
+        'arrayserializable'  => ArraySerializable::class,
+        'arraySerializable'  => ArraySerializable::class,
+        'ArraySerializable'  => ArraySerializable::class,
+        'classmethods'       => ClassMethods::class,
+        'classMethods'       => ClassMethods::class,
+        'ClassMethods'       => ClassMethods::class,
+        'delegatinghydrator' => DelegatingHydrator::class,
+        'delegatingHydrator' => DelegatingHydrator::class,
+        'DelegatingHydrator' => DelegatingHydrator::class,
+        'objectproperty'     => ObjectProperty::class,
+        'objectProperty'     => ObjectProperty::class,
+        'ObjectProperty'     => ObjectProperty::class,
+        'reflection'         => Reflection::class,
+        'Reflection'         => Reflection::class,
     ];
 
     /**
@@ -52,22 +48,70 @@ class HydratorPluginManager extends AbstractPluginManager
      * @var array
      */
     protected $factories = [
-        'Zend\Hydrator\DelegatingHydrator' => 'Zend\Hydrator\DelegatingHydratorFactory',
+        ArraySerializable::class                => InvokableFactory::class,
+        ClassMethods::class                     => InvokableFactory::class,
+        DelegatingHydrator::class               => DelegatingHydratorFactory::class,
+        ObjectProperty::class                   => InvokableFactory::class,
+        Reflection::class                       => InvokableFactory::class,
+
+        // v2 normalized FQCNs
+        'zendhydratorarrayserializable'         => InvokableFactory::class,
+        'zendhydratorclassmethods'              => InvokableFactory::class,
+        'zendhydratordelegatinghydrator'        => DelegatingHydratorFactory::class,
+        'zendhydratorobjectproperty'            => InvokableFactory::class,
+        'zendhydratorreflection'                => InvokableFactory::class,
     ];
 
     /**
-     * {@inheritDoc}
+     * Whether or not to share by default (v3)
+     *
+     * @var bool
      */
-    public function validatePlugin($plugin)
+    protected $sharedByDefault = false;
+
+    /**
+     * Whether or not to share by default (v2)
+     *
+     * @var bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * {inheritDoc}
+     */
+    protected $instanceOf = HydratorInterface::class;
+
+    /**
+     * Validate the plugin is of the expected type (v3).
+     *
+     * Checks that the filter loaded is either a valid callback or an instance
+     * of FilterInterface.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validate($instance)
     {
-        if ($plugin instanceof HydratorInterface) {
+        if ($instance instanceof $this->instanceOf) {
             // we're okay
             return;
         }
 
-        throw new Exception\RuntimeException(sprintf(
+        throw new InvalidServiceException(sprintf(
             'Plugin of type %s is invalid; must implement Zend\Hydrator\HydratorInterface',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin))
+            (is_object($instance) ? get_class($instance) : gettype($instance))
         ));
+    }
+
+    /**
+     * {@inheritDoc} (v2)
+     */
+    public function validatePlugin($plugin)
+    {
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 }

--- a/test/Aggregate/AggregateHydratorTest.php
+++ b/test/Aggregate/AggregateHydratorTest.php
@@ -12,6 +12,8 @@ namespace ZendTest\Hydrator\Aggregate;
 use PHPUnit_Framework_TestCase;
 use stdClass;
 use Zend\Hydrator\Aggregate\AggregateHydrator;
+use Zend\Hydrator\Aggregate\ExtractEvent;
+use Zend\Hydrator\Aggregate\HydrateEvent;
 
 /**
  * Unit tests for {@see AggregateHydrator}
@@ -48,9 +50,12 @@ class AggregateHydratorTest extends PHPUnit_Framework_TestCase
 
         $this
             ->eventManager
-            ->expects($this->once())
-            ->method('attachAggregate')
-            ->with($this->isInstanceOf('Zend\Hydrator\Aggregate\HydratorListener'), 123);
+            ->expects($this->exactly(2))
+            ->method('attach')
+            ->withConsecutive(
+                [$this->equalTo(HydrateEvent::EVENT_HYDRATE), $this->isType('callable'), 123],
+                [$this->equalTo(ExtractEvent::EVENT_EXTRACT), $this->isType('callable'), 123]
+            );
 
         $this->hydrator->add($attached, 123);
     }
@@ -65,7 +70,7 @@ class AggregateHydratorTest extends PHPUnit_Framework_TestCase
         $this
             ->eventManager
             ->expects($this->once())
-            ->method('trigger')
+            ->method('triggerEvent')
             ->with($this->isInstanceOf('Zend\Hydrator\Aggregate\HydrateEvent'));
 
         $this->assertSame($object, $this->hydrator->hydrate(['foo' => 'bar'], $object));
@@ -81,7 +86,7 @@ class AggregateHydratorTest extends PHPUnit_Framework_TestCase
         $this
             ->eventManager
             ->expects($this->once())
-            ->method('trigger')
+            ->method('triggerEvent')
             ->with($this->isInstanceOf('Zend\Hydrator\Aggregate\ExtractEvent'));
 
         $this->assertSame([], $this->hydrator->extract($object));

--- a/test/DelegatingHydratorFactoryTest.php
+++ b/test/DelegatingHydratorFactoryTest.php
@@ -10,20 +10,89 @@
 namespace ZendTest\Hydrator;
 
 use Interop\Container\ContainerInterface;
+use ReflectionProperty;
 use Zend\Hydrator\DelegatingHydrator;
 use Zend\Hydrator\DelegatingHydratorFactory;
+use Zend\Hydrator\HydratorPluginManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class DelegatingHydratorFactoryTest extends \PHPUnit_Framework_TestCase
 {
-    public function testFactory()
+    public function testV2Factory()
     {
+        $hydrators = $this->prophesize(HydratorPluginManager::class)->reveal();
         $prophesy = $this->prophesize(ServiceLocatorInterface::class);
         $prophesy->willImplement(ContainerInterface::class);
+        $prophesy->has(HydratorPluginManager::class)->willReturn(true);
+        $prophesy->get(HydratorPluginManager::class)->willReturn($hydrators);
+
         $factory = new DelegatingHydratorFactory();
         $this->assertInstanceOf(
             DelegatingHydrator::class,
             $factory->createService($prophesy->reveal())
         );
+    }
+
+    public function testFactoryUsesContainerToSeedDelegatingHydratorWhenItIsAHydratorPluginManager()
+    {
+        $hydrators = $this->prophesize(HydratorPluginManager::class)->reveal();
+        $factory = new DelegatingHydratorFactory();
+
+        $hydrator = $factory($hydrators, '');
+        $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
+        $this->assertAttributeSame($hydrators, 'hydrators', $hydrator);
+    }
+
+    public function testFactoryUsesHydratorPluginManagerServiceFromContainerToSeedDelegatingHydratorWhenAvailable()
+    {
+        $hydrators = $this->prophesize(HydratorPluginManager::class)->reveal();
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(HydratorPluginManager::class)->willReturn(true);
+        $container->get(HydratorPluginManager::class)->willReturn($hydrators);
+
+        $factory = new DelegatingHydratorFactory();
+
+        $hydrator = $factory($container->reveal(), '');
+        $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
+        $this->assertAttributeSame($hydrators, 'hydrators', $hydrator);
+    }
+
+    public function testFactoryUsesHydratorManagerServiceFromContainerToSeedDelegatingHydratorWhenAvailable()
+    {
+        $hydrators = $this->prophesize(HydratorPluginManager::class)->reveal();
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(HydratorPluginManager::class)->willReturn(false);
+        $container->has('HydratorManager')->willReturn(true);
+        $container->get('HydratorManager')->willReturn($hydrators);
+
+        $factory = new DelegatingHydratorFactory();
+
+        $hydrator = $factory($container->reveal(), '');
+        $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
+        $this->assertAttributeSame($hydrators, 'hydrators', $hydrator);
+    }
+
+    public function testFactoryCreatesHydratorPluginManagerToSeedDelegatingHydratorAsFallback()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(HydratorPluginManager::class)->willReturn(false);
+        $container->has('HydratorManager')->willReturn(false);
+
+        $factory = new DelegatingHydratorFactory();
+
+        $hydrator = $factory($container->reveal(), '');
+        $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
+
+        $r = new ReflectionProperty($hydrator, 'hydrators');
+        $r->setAccessible(true);
+        $hydrators = $r->getValue($hydrator);
+
+        $this->assertInstanceOf(HydratorPluginManager::class, $hydrators);
+
+        $property = method_exists($hydrators, 'configure')
+            ? 'creationContext' // v3
+            : 'serviceLocator'; // v2
+
+        $this->assertAttributeSame($container->reveal(), $property, $hydrators);
     }
 }

--- a/test/DelegatingHydratorFactoryTest.php
+++ b/test/DelegatingHydratorFactoryTest.php
@@ -9,17 +9,21 @@
 
 namespace ZendTest\Hydrator;
 
+use Interop\Container\ContainerInterface;
+use Zend\Hydrator\DelegatingHydrator;
 use Zend\Hydrator\DelegatingHydratorFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class DelegatingHydratorFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testFactory()
     {
-        $hydratorManager = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $prophesy = $this->prophesize(ServiceLocatorInterface::class);
+        $prophesy->willImplement(ContainerInterface::class);
         $factory = new DelegatingHydratorFactory();
         $this->assertInstanceOf(
-            'Zend\Hydrator\DelegatingHydrator',
-            $factory->createService($hydratorManager)
+            DelegatingHydrator::class,
+            $factory->createService($prophesy->reveal())
         );
     }
 }

--- a/test/DelegatingHydratorTest.php
+++ b/test/DelegatingHydratorTest.php
@@ -10,7 +10,10 @@
 namespace ZendTest\Hydrator;
 
 use ArrayObject;
+use Interop\Container\ContainerInterface;
+use Prophecy\Argument;
 use Zend\Hydrator\DelegatingHydrator;
+use Zend\Hydrator\HydratorInterface;
 
 /**
  * Unit tests for {@see DelegatingHydrator}
@@ -39,51 +42,30 @@ class DelegatingHydratorTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->hydrators = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
-        $this->hydrator = new DelegatingHydrator($this->hydrators);
+        $this->hydrators = $this->prophesize(ContainerInterface::class);
+        $this->hydrator = new DelegatingHydrator($this->hydrators->reveal());
         $this->object = new ArrayObject;
     }
 
     public function testExtract()
     {
-        $this->hydrators->expects($this->any())
-            ->method('has')
-            ->with('ArrayObject')
-            ->will($this->returnValue(true));
+        $hydrator = $this->prophesize(HydratorInterface::class);
+        $hydrator->extract($this->object)->willReturn(['foo' => 'bar']);
 
-        $hydrator = $this->getMock('Zend\Hydrator\HydratorInterface');
+        $this->hydrators->has(Argument::type(ArrayObject::class))->willReturn(true);
+        $this->hydrators->get(ArrayObject::class)->willReturn($hydrator->reveal());
 
-        $this->hydrators->expects($this->any())
-            ->method('get')
-            ->with('ArrayObject')
-            ->will($this->returnValue($hydrator));
-
-        $hydrator->expects($this->any())
-            ->method('extract')
-            ->with($this->object)
-            ->will($this->returnValue(['foo' => 'bar']));
-
-        $this->assertEquals(['foo' => 'bar'], $hydrator->extract($this->object));
+        $this->assertEquals(['foo' => 'bar'], $this->hydrator->extract($this->object));
     }
 
     public function testHydrate()
     {
-        $this->hydrators->expects($this->any())
-            ->method('has')
-            ->with('ArrayObject')
-            ->will($this->returnValue(true));
+        $hydrator = $this->prophesize(HydratorInterface::class);
+        $hydrator->hydrate(['foo' => 'bar'], $this->object)->willReturn($this->object);
 
-        $hydrator = $this->getMock('Zend\Hydrator\HydratorInterface');
+        $this->hydrators->has(Argument::type(ArrayObject::class))->willReturn(true);
+        $this->hydrators->get(ArrayObject::class)->willReturn($hydrator->reveal());
 
-        $this->hydrators->expects($this->any())
-            ->method('get')
-            ->with('ArrayObject')
-            ->will($this->returnValue($hydrator));
-
-        $hydrator->expects($this->any())
-            ->method('hydrate')
-            ->with(['foo' => 'bar'], $this->object)
-            ->will($this->returnValue($this->object));
-        $this->assertEquals($this->object, $hydrator->hydrate(['foo' => 'bar'], $this->object));
+        $this->assertEquals($this->object, $this->hydrator->hydrate(['foo' => 'bar'], $this->object));
     }
 }

--- a/test/HydratorManagerTest.php
+++ b/test/HydratorManagerTest.php
@@ -9,30 +9,28 @@
 
 namespace ZendTest\Hydrator;
 
+use Zend\Hydrator\Exception\RuntimeException;
+use Zend\Hydrator\HydratorInterface;
 use Zend\Hydrator\HydratorPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 
 class HydratorManagerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var HydratorPluginManager
-     */
-    protected $manager;
+    use CommonPluginManagerTrait;
 
-    public function setUp()
+    protected function getPluginManager()
     {
-        $this->manager = new HydratorPluginManager();
+        return new HydratorPluginManager(new ServiceManager());
     }
 
-    public function testRegisteringInvalidElementRaisesException()
+    protected function getV2InvalidPluginException()
     {
-        $this->setExpectedException('Zend\Hydrator\Exception\RuntimeException');
-        $this->manager->setService('test', $this);
+        return RuntimeException::class;
     }
 
-    public function testLoadingInvalidElementRaisesException()
+    protected function getInstanceOf()
     {
-        $this->manager->setInvokableClass('test', get_class($this));
-        $this->setExpectedException('Zend\Hydrator\Exception\RuntimeException');
-        $this->manager->get('test');
+        return HydratorInterface::class;
     }
 }

--- a/test/HydratorPluginManagerCompatibilityTest.php
+++ b/test/HydratorPluginManagerCompatibilityTest.php
@@ -15,7 +15,7 @@ use Zend\Hydrator\HydratorPluginManager;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 
-class HydratorManagerTest extends \PHPUnit_Framework_TestCase
+class HydratorPluginManagerCompatibilityTest extends \PHPUnit_Framework_TestCase
 {
     use CommonPluginManagerTrait;
 


### PR DESCRIPTION
This patch builds on #17, incorporating feedback and adding more dependency constraints and test builds.

In particular:

- zend-hydrator v2 and zend-stdlib v2 are incompatible. Additionally, zend-stdlib v3 and zend-eventmanager v2 are incompatible. As such, this version **MUST** target zend-stdlib and zend-eventmanager v3; that change has been made. An additional pull request against the 1.X series will be made shortly, providing forwards-compatibility for those releases.
- adds a build job per SM version, per PHP version.
- Updates the `DelegatingHydratorFactory` to ensure that the `DelegatingHydrator` it creates *always* receives a `HydratorPluginManager` instance.
- Fixes broken `AggregateHydrator` tests due to targetting v3 of zend-eventmanager; the `EventManagerInterface` in v2 did not define `triggerEvent()`, which was causing mocks to fail.

If tests pass, we can finally put this migration to bed!