### PR TITLE
Finalize forwards-compatibility support for zend-hydrator v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,8 @@ before_install:
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
 
 install:
-  - travis_retry composer install --no-interaction --ignore-platform-reqs
+  - if [[ $EVENT_MANAGER_VERSION != '' ]]; then COMPOSER_ROOT_VERSION=1.9.99 travis_retry composer install --no-interaction --ignore-platform-reqs ; fi
+  - if [[ $EVENT_MANAGER_VERSION == '' ]]; then travis_retry composer install --no-interaction --ignore-platform-reqs ; fi
 
 script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,18 @@ matrix:
   include:
     - php: 5.5
       env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
         - EXECUTE_CS_CHECK=true
-        - SERVICE_MANAGER_V2=TRUE
     - php: 5.6
       env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
         - EXECUTE_TEST_COVERALLS=true
-        - SERVICE_MANAGER_V2=TRUE
     - php: 7
       env:
-        - SERVICE_MANAGER_V2=TRUE
+        - SERVICE_MANAGER_VERSION="^2.7.3"
     - php: hhvm
       env:
-        - SERVICE_MANAGER_V2=TRUE
+        - SERVICE_MANAGER_VERSION="^2.7.3"
   allow_failures:
     - php: 7
 
@@ -39,8 +39,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
-  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
-  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,46 @@ branches:
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.local
+    - zf-mkdoc-theme
+
+env:
+  global:
+    - SITE_URL: https://zendframework.github.io/zend-hydrator
+    - GH_USER_NAME: "Matthew Weier O'Phinney"
+    - GH_USER_EMAIL: matthew@weierophinney.net
+    - GH_REF: github.com/zendframework/zend-hydrator.git
+    - secure: "xMnwSntQA+rIsQIIklwziEROWMlF9vsq7L1BOJwnNMFmfImnn/2RxHdqqtQ6q7npsHioUqn23YZyFTLCGZiM7SLcBQndiW1Qmgz8VE2hk1ur+d2PIewu7v3aTgOOB+igK0Re43ZQKX/Vl2C92IlBmilyWzFBqE81kdw0NmxHq8QqpNAgnTkYaye4MOiW+giLtdkCSHHYn6/zmOgc0A630X7YKy7Ru+bYGGXXVb2jzq7mdapE0XZpgjFkYiwwOgA8AQLwWJF87QwaGrdeej1PbAInQDoeMWf9o2C5Ezl57+IWJfR6yTs29zFDUXo6hcWyQ4Rurpgei0Jt30LDZohZ4xY0LZkJ0wochprh5riXmQ2cM/i/RvQjQ2hgJOcDHyUPYfaoyD4CRgA1KvkjD7dRypQ03cPyjHXluZat+ZQkFMa6W5K/M2brGLRhW3echko3/1riMEzFshhqMO7RtZ9GeHg8fNxlgJFZI6R8KvIE+pM7OiZUdPYlfqOSZKr2kxhF2mJQ+a7I3EguLc2cgvu4c8IL34dOrmInhsj5kkIapLpiEIyN0G8rV6oI/nHXYBDgrEckjozjAkdOkInf/TowRNODQmrR7eUeBJCLPbRHFcY5aE4cGGGl7J1KM6rx2vV9Boc3KTxY0+cC9JegR8X7UaqGLqTSJ7k5FyapoxfYSJA="
 
 matrix:
   fast_finish: true
   include:
     - php: 5.5
       env:
-        - SERVICE_MANAGER_VERSION="^2.7.3"
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
+        - EVENT_MANAGER_VERSION="^2.6.2"
+    - php: 5.6
+      env:
+        - EXECUTE_TEST_COVERALLS=true
+        - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
+        - PATH="$HOME/.local/bin:$PATH"
     - php: 5.6
       env:
         - SERVICE_MANAGER_VERSION="^2.7.3"
-        - EXECUTE_TEST_COVERALLS=true
+        - EVENT_MANAGER_VERSION="^2.6.2"
+    - php: 7
     - php: 7
       env:
         - SERVICE_MANAGER_VERSION="^2.7.3"
+        - EVENT_MANAGER_VERSION="^2.6.2"
+    - php: hhvm
     - php: hhvm
       env:
         - SERVICE_MANAGER_VERSION="^2.7.3"
+        - EVENT_MANAGER_VERSION="^2.6.2"
   allow_failures:
     - php: 7
 
@@ -39,8 +61,10 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
+  - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^3.0" ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs
@@ -49,6 +73,10 @@ script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit ; fi
   - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/phpcs ; fi
+  - if [[ $DEPLOY_DOCS == "true" && "$TRAVIS_TEST_RESULT" == "0" ]]; then wget -O theme-installer.sh "https://raw.githubusercontent.com/zendframework/zf-mkdoc-theme/master/theme-installer.sh" ; chmod 755 theme-installer.sh ; ./theme-installer.sh ; fi
+
+after_success:
+  - if [[ $DEPLOY_DOCS == "true" ]]; then echo "Preparing to build and deploy documentation" ; ./zf-mkdoc-theme/deploy.sh ; echo "Completed deploying documentation" ; fi
 
 after_script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/coveralls ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,17 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+        - SERVICE_MANAGER_V2=TRUE
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+        - SERVICE_MANAGER_V2=TRUE
     - php: 7
-    - php: hhvm 
+      env:
+        - SERVICE_MANAGER_V2=TRUE
+    - php: hhvm
+      env:
+        - SERVICE_MANAGER_V2=TRUE
   allow_failures:
     - php: 7
 
@@ -33,6 +39,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
+  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
         - SERVICE_MANAGER_VERSION="^2.7.3"
         - EVENT_MANAGER_VERSION="^2.6.2"
   allow_failures:
-    - php: 7
+    - php: hhvm
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "zendframework/zend-stdlib": "dev-develop as 2.7"
     },
     "require-dev": {
-        "zendframework/zend-eventmanager": "^2.7.3 || ^3.0",
+        "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-inputfilter": "dev-feature/zf3-improvement as 2.5.1",
         "zendframework/zend-serializer": "dev-develop",
         "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
@@ -26,7 +26,7 @@
         "squizlabs/php_codesniffer": "^2.0@dev"
     },
     "suggest": {
-        "zendframework/zend-eventmanager": "^2.7.3 || ^3.0, to support aggregate hydrator usage",
+        "zendframework/zend-eventmanager": "^2.6.2 || ^3.0, to support aggregate hydrator usage",
         "zendframework/zend-serializer": "^2.5.1, to use the SerializableStrategy",
         "zendframework/zend-servicemanager": "^2.7.3 || ^3.0, to support hydrator plugin manager usage",
         "zendframework/zend-filter": "^2.5.1, to support naming strategy hydrator usage"

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "dev-develop as 2.7",
-        "zendframework/zend-servicemanager": "2.7.5"
+        "zendframework/zend-stdlib": "dev-develop as 2.5.1"
     },
     "require-dev": {
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-inputfilter": "dev-develop as 2.6.0",
         "zendframework/zend-serializer": "dev-develop",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-filter": "^2.6.0",
         "phpunit/PHPUnit": "~4.0",
         "squizlabs/php_codesniffer": "^2.0@dev"
@@ -29,7 +29,7 @@
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0, to support aggregate hydrator usage",
         "zendframework/zend-serializer": "^2.5.1, to use the SerializableStrategy",
         "zendframework/zend-servicemanager": "^2.7.3 || ^3.0, to support hydrator plugin manager usage",
-        "zendframework/zend-filter": "^2.5.1, to support naming strategy hydrator usage"
+        "zendframework/zend-filter": "^2.6.0, to support naming strategy hydrator usage"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -13,23 +13,23 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "dev-develop as 2.5.1"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
-        "zendframework/zend-inputfilter": "dev-develop as 2.6.0",
-        "zendframework/zend-serializer": "dev-develop",
+        "zendframework/zend-inputfilter": "^2.6",
+        "zendframework/zend-serializer": "^2.6.1",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-        "zendframework/zend-filter": "^2.6.0",
+        "zendframework/zend-filter": "^2.6",
         "phpunit/PHPUnit": "~4.0",
         "squizlabs/php_codesniffer": "^2.0@dev"
     },
     "suggest": {
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0, to support aggregate hydrator usage",
-        "zendframework/zend-serializer": "^2.5.1, to use the SerializableStrategy",
-        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0, to support hydrator plugin manager usage",
-        "zendframework/zend-filter": "^2.6.0, to support naming strategy hydrator usage"
+        "zendframework/zend-serializer": "^2.6.1, to use the SerializableStrategy",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3, to support hydrator plugin manager usage",
+        "zendframework/zend-filter": "^2.6, to support naming strategy hydrator usage"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "^2.7.4"
+        "zendframework/zend-stdlib": "dev-develop as 2.7"
     },
     "require-dev": {
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,9 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev",
-            "dev-develop": "1.1-dev"
+            "dev-release-1.0": "1.0-dev",
+            "dev-master": "2.0-dev",
+            "dev-develop": "2.1-dev"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "dev-develop as 2.7"
+        "zendframework/zend-stdlib": "dev-develop as 2.7",
+        "zendframework/zend-servicemanager": "2.7.5"
     },
     "require-dev": {
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-inputfilter": "dev-develop as 2.6.0",
         "zendframework/zend-serializer": "dev-develop",
-        "zendframework/zend-servicemanager": "^2.7.4 || ^3.0",
         "zendframework/zend-filter": "^2.6.0",
         "phpunit/PHPUnit": "~4.0",
         "squizlabs/php_codesniffer": "^2.0@dev"

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "dev-develop as 2.5.1"
+        "zendframework/zend-stdlib": "dev-develop as 2.7"
     },
     "require-dev": {
         "zendframework/zend-eventmanager": "^3.0",
         "zendframework/zend-inputfilter": "dev-feature/zf3-improvement as 2.5.1",
-        "zendframework/zend-serializer": "^2.5.1",
+        "zendframework/zend-serializer": "dev-develop",
         "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
         "zendframework/zend-filter": "^2.5.1",
         "phpunit/PHPUnit": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "dev-develop as 2.7"
+        "zendframework/zend-stdlib": "^2.7.4"
     },
     "require-dev": {
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "^2.5.1"
+        "zendframework/zend-stdlib": "dev-develop as 2.5.1"
     },
     "require-dev": {
-        "zendframework/zend-eventmanager": "^2.5.1",
-        "zendframework/zend-inputfilter": "^2.5.1",
+        "zendframework/zend-eventmanager": "^3.0",
+        "zendframework/zend-inputfilter": "dev-feature/zf3-improvement as 2.5.1",
         "zendframework/zend-serializer": "^2.5.1",
-        "zendframework/zend-servicemanager": "^2.5.1",
+        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
         "zendframework/zend-filter": "^2.5.1",
         "phpunit/PHPUnit": "~4.0",
         "squizlabs/php_codesniffer": "^2.0@dev"
@@ -43,5 +43,11 @@
         "psr-4": {
             "ZendTest\\Hydrator\\": "test/"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type" : "vcs",
+            "url" : "git@github.com:gianarb/zend-inputfilter.git"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     },
     "require-dev": {
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
-        "zendframework/zend-inputfilter": "dev-feature/zf3-improvement as 2.5.1",
+        "zendframework/zend-inputfilter": "dev-develop as 2.6.0",
         "zendframework/zend-serializer": "dev-develop",
-        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
-        "zendframework/zend-filter": "^2.5.1",
+        "zendframework/zend-servicemanager": "^2.7.4 || ^3.0",
+        "zendframework/zend-filter": "^2.6.0",
         "phpunit/PHPUnit": "~4.0",
         "squizlabs/php_codesniffer": "^2.0@dev"
     },
@@ -43,11 +43,5 @@
         "psr-4": {
             "ZendTest\\Hydrator\\": "test/"
         }
-    },
-    "repositories": [
-        {
-            "type" : "vcs",
-            "url" : "git@github.com:gianarb/zend-inputfilter.git"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "zendframework/zend-stdlib": "dev-develop as 2.7"
     },
     "require-dev": {
-        "zendframework/zend-eventmanager": "^3.0",
+        "zendframework/zend-eventmanager": "^2.7.3 || ^3.0",
         "zendframework/zend-inputfilter": "dev-feature/zf3-improvement as 2.5.1",
         "zendframework/zend-serializer": "dev-develop",
         "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
@@ -26,9 +26,9 @@
         "squizlabs/php_codesniffer": "^2.0@dev"
     },
     "suggest": {
-        "zendframework/zend-eventmanager": "^2.5.1, to support aggregate hydrator usage",
+        "zendframework/zend-eventmanager": "^2.7.3 || ^3.0, to support aggregate hydrator usage",
         "zendframework/zend-serializer": "^2.5.1, to use the SerializableStrategy",
-        "zendframework/zend-servicemanager": "^2.5.1, to support hydrator plugin manager usage",
+        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0, to support hydrator plugin manager usage",
         "zendframework/zend-filter": "^2.5.1, to support naming strategy hydrator usage"
     },
     "minimum-stability": "dev",

--- a/src/Aggregate/AggregateHydrator.php
+++ b/src/Aggregate/AggregateHydrator.php
@@ -34,8 +34,8 @@ class AggregateHydrator implements HydratorInterface, EventManagerAwareInterface
      */
     public function add(HydratorInterface $hydrator, $priority = self::DEFAULT_PRIORITY)
     {
-        $aggregate = new HydratorListener($hydrator);
-        $aggregate->attach($this->getEventManager(), $priority);
+        $listener = new HydratorListener($hydrator);
+        $listener->attach($this->getEventManager(), $priority);
     }
 
     /**

--- a/src/Aggregate/AggregateHydrator.php
+++ b/src/Aggregate/AggregateHydrator.php
@@ -34,7 +34,8 @@ class AggregateHydrator implements HydratorInterface, EventManagerAwareInterface
      */
     public function add(HydratorInterface $hydrator, $priority = self::DEFAULT_PRIORITY)
     {
-        $this->getEventManager()->attachAggregate(new HydratorListener($hydrator), $priority);
+        $aggregate = new HydratorListener($hydrator);
+        $aggregate->attach($this->getEventManager(), $priority);
     }
 
     /**
@@ -44,7 +45,7 @@ class AggregateHydrator implements HydratorInterface, EventManagerAwareInterface
     {
         $event = new ExtractEvent($this, $object);
 
-        $this->getEventManager()->trigger($event);
+        $this->getEventManager()->triggerEvent($event);
 
         return $event->getExtractedData();
     }
@@ -56,7 +57,7 @@ class AggregateHydrator implements HydratorInterface, EventManagerAwareInterface
     {
         $event = new HydrateEvent($this, $object, $data);
 
-        $this->getEventManager()->trigger($event);
+        $this->getEventManager()->triggerEvent($event);
 
         return $event->getHydratedObject();
     }

--- a/src/DelegatingHydrator.php
+++ b/src/DelegatingHydrator.php
@@ -9,21 +9,21 @@
 
 namespace Zend\Hydrator;
 
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Interop\Container\ContainerInterface;
 
 class DelegatingHydrator implements HydratorInterface
 {
     /**
-     * @var ServiceLocatorInterface
+     * @var ContainerInterface
      */
     protected $hydrators;
 
     /**
      * Constructor
      *
-     * @param ServiceLocatorInterface $hydrators
+     * @param ContainerInterface $hydrators
      */
-    public function __construct(ServiceLocatorInterface $hydrators)
+    public function __construct(ContainerInterface $hydrators)
     {
         $this->hydrators = $hydrators;
     }

--- a/src/DelegatingHydratorFactory.php
+++ b/src/DelegatingHydratorFactory.php
@@ -23,7 +23,7 @@ class DelegatingHydratorFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $this($serviceLocator, '');
+        return $this($serviceLocator, '');
     }
 
     /**

--- a/src/DelegatingHydratorFactory.php
+++ b/src/DelegatingHydratorFactory.php
@@ -62,7 +62,7 @@ class DelegatingHydratorFactory implements FactoryInterface
         if ($container->has('HydratorManager')) {
             return $container->get('HydratorManager');
         }
-        
+
         // Fallback: create one
         return new HydratorPluginManager($container);
     }

--- a/src/DelegatingHydratorFactory.php
+++ b/src/DelegatingHydratorFactory.php
@@ -23,11 +23,11 @@ class DelegatingHydratorFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $this($serviceLocator);
+        $this($serviceLocator, '');
     }
 
     /**
-     * v3
+     * Creates DelegatingHydrator (v3)
      *
      * @param ContainerInterface $container
      * @param string $requestedName
@@ -36,7 +36,6 @@ class DelegatingHydratorFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-
         // Assume that this factory is registered with the HydratorManager,
         // and just pass it directly on.
         return new DelegatingHydrator($container);

--- a/src/DelegatingHydratorFactory.php
+++ b/src/DelegatingHydratorFactory.php
@@ -36,8 +36,34 @@ class DelegatingHydratorFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        // Assume that this factory is registered with the HydratorManager,
-        // and just pass it directly on.
+        $container = $this->marshalHydratorPluginManager($container);
         return new DelegatingHydrator($container);
+    }
+
+    /**
+     * Locate and return a HydratorPluginManager instance.
+     *
+     * @param ContainerInterface $container
+     * @return HydratorPluginManager
+     */
+    private function marshalHydratorPluginManager(ContainerInterface $container)
+    {
+        // Already one? Return it.
+        if ($container instanceof HydratorPluginManager) {
+            return $container;
+        }
+
+        // As typically registered with v3 (FQCN)
+        if ($container->has(HydratorPluginManager::class)) {
+            return $container->get(HydratorPluginManager::class);
+        }
+
+        // As registered by zend-mvc
+        if ($container->has('HydratorManager')) {
+            return $container->get('HydratorManager');
+        }
+        
+        // Fallback: create one
+        return new HydratorPluginManager($container);
     }
 }

--- a/src/DelegatingHydratorFactory.php
+++ b/src/DelegatingHydratorFactory.php
@@ -9,21 +9,36 @@
 
 namespace Zend\Hydrator;
 
+use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class DelegatingHydratorFactory implements FactoryInterface
 {
     /**
-     * Creates DelegatingHydrator
+     * Creates DelegatingHydrator (v2)
      *
      * @param  ServiceLocatorInterface $serviceLocator
      * @return DelegatingHydrator
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
+        $this($serviceLocator);
+    }
+
+    /**
+     * v3
+     *
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param array|null $options
+     * @return DelegatingHydrator
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+
         // Assume that this factory is registered with the HydratorManager,
         // and just pass it directly on.
-        return new DelegatingHydrator($serviceLocator);
+        return new DelegatingHydrator($container);
     }
 }

--- a/src/HydratorPluginManager.php
+++ b/src/HydratorPluginManager.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Hydrator;
 
-use Doctrine\Instantiator\Exception\InvalidArgumentException;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
@@ -56,11 +55,18 @@ class HydratorPluginManager extends AbstractPluginManager
      * @var array
      */
     protected $factories = [
-        ArraySerializable::class  => InvokableFactory::class,
-        ClassMethods::class       => InvokableFactory::class,
-        DelegatingHydrator::class => DelegatingHydratorFactory::class,
-        ObjectProperty::class     => InvokableFactory::class,
-        Reflection::class         => InvokableFactory::class,
+        ArraySerializable::class                => InvokableFactory::class,
+        ClassMethods::class                     => InvokableFactory::class,
+        DelegatingHydrator::class               => DelegatingHydratorFactory::class,
+        ObjectProperty::class                   => InvokableFactory::class,
+        Reflection::class                       => InvokableFactory::class,
+
+        // v2 canonical FQCNs
+        'zendhydratorarrayserializable'         => InvokableFactory::class,
+        'zendhydratorclassmethods'              => InvokableFactory::class,
+        'zendhydratordelegatinghydrator'        => DelegatingHydratorFactory::class,
+        'zendhydratorhydratorbbjectproperty'    => InvokableFactory::class,
+        'zendhydratorzendhydratorreflection'    => InvokableFactory::class,
     ];
 
     /**

--- a/src/HydratorPluginManager.php
+++ b/src/HydratorPluginManager.php
@@ -58,8 +58,8 @@ class HydratorPluginManager extends AbstractPluginManager
         'zendhydratorarrayserializable'         => InvokableFactory::class,
         'zendhydratorclassmethods'              => InvokableFactory::class,
         'zendhydratordelegatinghydrator'        => DelegatingHydratorFactory::class,
-        'zendhydratorhydratorbbjectproperty'    => InvokableFactory::class,
-        'zendhydratorzendhydratorreflection'    => InvokableFactory::class,
+        'zendhydratorobjectproperty'            => InvokableFactory::class,
+        'zendhydratorreflection'                => InvokableFactory::class,
     ];
 
     /**

--- a/src/HydratorPluginManager.php
+++ b/src/HydratorPluginManager.php
@@ -21,13 +21,6 @@ use Zend\ServiceManager\Factory\InvokableFactory;
 class HydratorPluginManager extends AbstractPluginManager
 {
     /**
-     * Whether or not to share by default
-     *
-     * @var bool
-     */
-    protected $sharedByDefault = false;
-
-    /**
      * Default aliases
      *
      * @var array
@@ -61,13 +54,27 @@ class HydratorPluginManager extends AbstractPluginManager
         ObjectProperty::class                   => InvokableFactory::class,
         Reflection::class                       => InvokableFactory::class,
 
-        // v2 canonical FQCNs
+        // v2 normalized FQCNs
         'zendhydratorarrayserializable'         => InvokableFactory::class,
         'zendhydratorclassmethods'              => InvokableFactory::class,
         'zendhydratordelegatinghydrator'        => DelegatingHydratorFactory::class,
         'zendhydratorhydratorbbjectproperty'    => InvokableFactory::class,
         'zendhydratorzendhydratorreflection'    => InvokableFactory::class,
     ];
+
+    /**
+     * Whether or not to share by default (v3)
+     *
+     * @var bool
+     */
+    protected $sharedByDefault = false;
+
+    /**
+     * Whether or not to share by default (v2)
+     *
+     * @var bool
+     */
+    protected $shareByDefault = false;
 
     /**
      * {inheritDoc}

--- a/src/HydratorPluginManager.php
+++ b/src/HydratorPluginManager.php
@@ -26,7 +26,7 @@ class HydratorPluginManager extends AbstractPluginManager
      *
      * @var bool
      */
-    protected $shareByDefault = false;
+    protected $sharedByDefault = false;
 
     /**
      * Default aliases
@@ -35,10 +35,19 @@ class HydratorPluginManager extends AbstractPluginManager
      */
     protected $aliases = [
         'arrayserializable'  => ArraySerializable::class,
+        'arraySerializable'  => ArraySerializable::class,
+        'ArraySerializable'  => ArraySerializable::class,
         'classmethods'       => ClassMethods::class,
+        'classMethods'       => ClassMethods::class,
+        'ClassMethods'       => ClassMethods::class,
         'delegatinghydrator' => DelegatingHydrator::class,
+        'delegatingHydrator' => DelegatingHydrator::class,
+        'DelegatingHydrator' => DelegatingHydrator::class,
         'objectproperty'     => ObjectProperty::class,
+        'objectProperty'     => ObjectProperty::class,
+        'ObjectProperty'     => ObjectProperty::class,
         'reflection'         => Reflection::class,
+        'Reflection'         => Reflection::class,
     ];
 
     /**

--- a/src/HydratorPluginManager.php
+++ b/src/HydratorPluginManager.php
@@ -64,6 +64,11 @@ class HydratorPluginManager extends AbstractPluginManager
     ];
 
     /**
+     * {inheritDoc}
+     */
+    protected $instanceOf = HydratorInterface::class;
+
+    /**
      * Validate the plugin is of the expected type (v3).
      *
      * Checks that the filter loaded is either a valid callback or an instance
@@ -74,12 +79,12 @@ class HydratorPluginManager extends AbstractPluginManager
      */
     public function validate($instance)
     {
-        if ($instance instanceof HydratorInterface) {
+        if ($instance instanceof $this->instanceOf) {
             // we're okay
             return;
         }
 
-        throw new Exception\RuntimeException(sprintf(
+        throw new InvalidServiceException(sprintf(
             'Plugin of type %s is invalid; must implement Zend\Hydrator\HydratorInterface',
             (is_object($instance) ? get_class($instance) : gettype($instance))
         ));
@@ -90,6 +95,10 @@ class HydratorPluginManager extends AbstractPluginManager
      */
     public function validatePlugin($plugin)
     {
-        $this->validate($plugin);
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 }

--- a/test/Aggregate/AggregateHydratorTest.php
+++ b/test/Aggregate/AggregateHydratorTest.php
@@ -49,7 +49,7 @@ class AggregateHydratorTest extends PHPUnit_Framework_TestCase
         $this
             ->eventManager
             ->expects($this->once())
-            ->method('attachAggregate')
+            ->method('attach')
             ->with($this->isInstanceOf('Zend\Hydrator\Aggregate\HydratorListener'), 123);
 
         $this->hydrator->add($attached, 123);
@@ -65,7 +65,7 @@ class AggregateHydratorTest extends PHPUnit_Framework_TestCase
         $this
             ->eventManager
             ->expects($this->once())
-            ->method('trigger')
+            ->method('triggerEvent')
             ->with($this->isInstanceOf('Zend\Hydrator\Aggregate\HydrateEvent'));
 
         $this->assertSame($object, $this->hydrator->hydrate(['foo' => 'bar'], $object));
@@ -81,7 +81,7 @@ class AggregateHydratorTest extends PHPUnit_Framework_TestCase
         $this
             ->eventManager
             ->expects($this->once())
-            ->method('trigger')
+            ->method('triggerEvent')
             ->with($this->isInstanceOf('Zend\Hydrator\Aggregate\ExtractEvent'));
 
         $this->assertSame([], $this->hydrator->extract($object));

--- a/test/Aggregate/AggregateHydratorTest.php
+++ b/test/Aggregate/AggregateHydratorTest.php
@@ -12,6 +12,8 @@ namespace ZendTest\Hydrator\Aggregate;
 use PHPUnit_Framework_TestCase;
 use stdClass;
 use Zend\Hydrator\Aggregate\AggregateHydrator;
+use Zend\Hydrator\Aggregate\ExtractEvent;
+use Zend\Hydrator\Aggregate\HydrateEvent;
 
 /**
  * Unit tests for {@see AggregateHydrator}
@@ -48,9 +50,12 @@ class AggregateHydratorTest extends PHPUnit_Framework_TestCase
 
         $this
             ->eventManager
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('attach')
-            ->with($this->isInstanceOf('Zend\Hydrator\Aggregate\HydratorListener'), 123);
+            ->withConsecutive(
+                [$this->equalTo(HydrateEvent::EVENT_HYDRATE), $this->isType('callable'), 123],
+                [$this->equalTo(ExtractEvent::EVENT_EXTRACT), $this->isType('callable'), 123]
+            );
 
         $this->hydrator->add($attached, 123);
     }

--- a/test/DelegatingHydratorFactoryTest.php
+++ b/test/DelegatingHydratorFactoryTest.php
@@ -10,20 +10,89 @@
 namespace ZendTest\Hydrator;
 
 use Interop\Container\ContainerInterface;
+use ReflectionProperty;
 use Zend\Hydrator\DelegatingHydrator;
 use Zend\Hydrator\DelegatingHydratorFactory;
+use Zend\Hydrator\HydratorPluginManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class DelegatingHydratorFactoryTest extends \PHPUnit_Framework_TestCase
 {
-    public function testFactory()
+    public function testV2Factory()
     {
+        $hydrators = $this->prophesize(HydratorPluginManager::class)->reveal();
         $prophesy = $this->prophesize(ServiceLocatorInterface::class);
         $prophesy->willImplement(ContainerInterface::class);
+        $prophesy->has(HydratorPluginManager::class)->willReturn(true);
+        $prophesy->get(HydratorPluginManager::class)->willReturn($hydrators);
+
         $factory = new DelegatingHydratorFactory();
         $this->assertInstanceOf(
             DelegatingHydrator::class,
             $factory->createService($prophesy->reveal())
         );
+    }
+
+    public function testFactoryUsesContainerToSeedDelegatingHydratorWhenItIsAHydratorPluginManager()
+    {
+        $hydrators = $this->prophesize(HydratorPluginManager::class)->reveal();
+        $factory = new DelegatingHydratorFactory();
+
+        $hydrator = $factory($hydrators, '');
+        $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
+        $this->assertAttributeSame($hydrators, 'hydrators', $hydrator);
+    }
+
+    public function testFactoryUsesHydratorPluginManagerServiceFromContainerToSeedDelegatingHydratorWhenAvailable()
+    {
+        $hydrators = $this->prophesize(HydratorPluginManager::class)->reveal();
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(HydratorPluginManager::class)->willReturn(true);
+        $container->get(HydratorPluginManager::class)->willReturn($hydrators);
+
+        $factory = new DelegatingHydratorFactory();
+
+        $hydrator = $factory($container->reveal(), '');
+        $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
+        $this->assertAttributeSame($hydrators, 'hydrators', $hydrator);
+    }
+
+    public function testFactoryUsesHydratorManagerServiceFromContainerToSeedDelegatingHydratorWhenAvailable()
+    {
+        $hydrators = $this->prophesize(HydratorPluginManager::class)->reveal();
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(HydratorPluginManager::class)->willReturn(false);
+        $container->has('HydratorManager')->willReturn(true);
+        $container->get('HydratorManager')->willReturn($hydrators);
+
+        $factory = new DelegatingHydratorFactory();
+
+        $hydrator = $factory($container->reveal(), '');
+        $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
+        $this->assertAttributeSame($hydrators, 'hydrators', $hydrator);
+    }
+
+    public function testFactoryCreatesHydratorPluginManagerToSeedDelegatingHydratorAsFallback()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(HydratorPluginManager::class)->willReturn(false);
+        $container->has('HydratorManager')->willReturn(false);
+
+        $factory = new DelegatingHydratorFactory();
+
+        $hydrator = $factory($container->reveal(), '');
+        $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
+
+        $r = new ReflectionProperty($hydrator, 'hydrators');
+        $r->setAccessible(true);
+        $hydrators = $r->getValue($hydrator);
+
+        $this->assertInstanceOf(HydratorPluginManager::class, $hydrators);
+
+        $property = method_exists($hydrators, 'configure')
+            ? 'creationContext' // v3
+            : 'serviceLocator'; // v2
+
+        $this->assertAttributeSame($container->reveal(), $property, $hydrators);
     }
 }

--- a/test/DelegatingHydratorFactoryTest.php
+++ b/test/DelegatingHydratorFactoryTest.php
@@ -9,17 +9,21 @@
 
 namespace ZendTest\Hydrator;
 
+use Interop\Container\ContainerInterface;
+use Zend\Hydrator\DelegatingHydrator;
 use Zend\Hydrator\DelegatingHydratorFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class DelegatingHydratorFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testFactory()
     {
-        $hydratorManager = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $prophesy = $this->prophesize(ServiceLocatorInterface::class);
+        $prophesy->willImplement(ContainerInterface::class);
         $factory = new DelegatingHydratorFactory();
         $this->assertInstanceOf(
-            'Zend\Hydrator\DelegatingHydrator',
-            $factory->createService($hydratorManager)
+            DelegatingHydrator::class,
+            $factory->createService($prophesy->reveal())
         );
     }
 }

--- a/test/DelegatingHydratorTest.php
+++ b/test/DelegatingHydratorTest.php
@@ -10,7 +10,10 @@
 namespace ZendTest\Hydrator;
 
 use ArrayObject;
+use Interop\Container\ContainerInterface;
+use Prophecy\Argument;
 use Zend\Hydrator\DelegatingHydrator;
+use Zend\Hydrator\HydratorInterface;
 
 /**
  * Unit tests for {@see DelegatingHydrator}
@@ -39,51 +42,30 @@ class DelegatingHydratorTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->hydrators = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
-        $this->hydrator = new DelegatingHydrator($this->hydrators);
+        $this->hydrators = $this->prophesize(ContainerInterface::class);
+        $this->hydrator = new DelegatingHydrator($this->hydrators->reveal());
         $this->object = new ArrayObject;
     }
 
     public function testExtract()
     {
-        $this->hydrators->expects($this->any())
-            ->method('has')
-            ->with('ArrayObject')
-            ->will($this->returnValue(true));
+        $hydrator = $this->prophesize(HydratorInterface::class);
+        $hydrator->extract($this->object)->willReturn(['foo' => 'bar']);
 
-        $hydrator = $this->getMock('Zend\Hydrator\HydratorInterface');
+        $this->hydrators->has(Argument::type(ArrayObject::class))->willReturn(true);
+        $this->hydrators->get(ArrayObject::class)->willReturn($hydrator->reveal());
 
-        $this->hydrators->expects($this->any())
-            ->method('get')
-            ->with('ArrayObject')
-            ->will($this->returnValue($hydrator));
-
-        $hydrator->expects($this->any())
-            ->method('extract')
-            ->with($this->object)
-            ->will($this->returnValue(['foo' => 'bar']));
-
-        $this->assertEquals(['foo' => 'bar'], $hydrator->extract($this->object));
+        $this->assertEquals(['foo' => 'bar'], $this->hydrator->extract($this->object));
     }
 
     public function testHydrate()
     {
-        $this->hydrators->expects($this->any())
-            ->method('has')
-            ->with('ArrayObject')
-            ->will($this->returnValue(true));
+        $hydrator = $this->prophesize(HydratorInterface::class);
+        $hydrator->hydrate(['foo' => 'bar'], $this->object)->willReturn($this->object);
 
-        $hydrator = $this->getMock('Zend\Hydrator\HydratorInterface');
+        $this->hydrators->has(Argument::type(ArrayObject::class))->willReturn(true);
+        $this->hydrators->get(ArrayObject::class)->willReturn($hydrator->reveal());
 
-        $this->hydrators->expects($this->any())
-            ->method('get')
-            ->with('ArrayObject')
-            ->will($this->returnValue($hydrator));
-
-        $hydrator->expects($this->any())
-            ->method('hydrate')
-            ->with(['foo' => 'bar'], $this->object)
-            ->will($this->returnValue($this->object));
-        $this->assertEquals($this->object, $hydrator->hydrate(['foo' => 'bar'], $this->object));
+        $this->assertEquals($this->object, $this->hydrator->hydrate(['foo' => 'bar'], $this->object));
     }
 }

--- a/test/HydratorManagerTest.php
+++ b/test/HydratorManagerTest.php
@@ -9,32 +9,28 @@
 
 namespace ZendTest\Hydrator;
 
-use phpDocumentor\Reflection\DocBlock\Serializer;
+use Zend\Hydrator\Exception\RuntimeException;
+use Zend\Hydrator\HydratorInterface;
 use Zend\Hydrator\HydratorPluginManager;
 use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 
 class HydratorManagerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var HydratorPluginManager
-     */
-    protected $manager;
+    use CommonPluginManagerTrait;
 
-    public function setUp()
+    protected function getPluginManager()
     {
-        $this->manager = new HydratorPluginManager(new ServiceManager());
+        return new HydratorPluginManager(new ServiceManager());
     }
 
-    public function testRegisteringInvalidElementRaisesException()
+    protected function getV2InvalidPluginException()
     {
-        $this->setExpectedException('Zend\Hydrator\Exception\RuntimeException');
-        $this->manager->setService('test', $this);
+        return RuntimeException::class;
     }
 
-    public function testLoadingInvalidElementRaisesException()
+    protected function getInstanceOf()
     {
-        $this->manager->setInvokableClass('test', get_class($this));
-        $this->setExpectedException('Zend\Hydrator\Exception\RuntimeException');
-        $this->manager->get('test');
+        return HydratorInterface::class;
     }
 }

--- a/test/HydratorManagerTest.php
+++ b/test/HydratorManagerTest.php
@@ -9,7 +9,9 @@
 
 namespace ZendTest\Hydrator;
 
+use phpDocumentor\Reflection\DocBlock\Serializer;
 use Zend\Hydrator\HydratorPluginManager;
+use Zend\ServiceManager\ServiceManager;
 
 class HydratorManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,7 +22,7 @@ class HydratorManagerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->manager = new HydratorPluginManager();
+        $this->manager = new HydratorPluginManager(new ServiceManager());
     }
 
     public function testRegisteringInvalidElementRaisesException()

--- a/test/HydratorPluginManagerCompatibilityTest.php
+++ b/test/HydratorPluginManagerCompatibilityTest.php
@@ -15,7 +15,7 @@ use Zend\Hydrator\HydratorPluginManager;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 
-class HydratorManagerTest extends \PHPUnit_Framework_TestCase
+class HydratorPluginManagerCompatibilityTest extends \PHPUnit_Framework_TestCase
 {
     use CommonPluginManagerTrait;
 


### PR DESCRIPTION
This builds on #23 to provide equivalent support for the v1 series. The primary difference is that it tests against both zend-servicemanager **and** zend-eventmanager v2 and v3. When the latter is at v2, it forces usage of zend-stdlib v2 as well, and sets the `COMPOSER_ROOT_VERSION` to `1.9.99` to ensure no circular dependency issues occur.