### PR TITLE
[DOC] Fix a minor phpdoc comment

### DIFF
--- a/src/AbstractHydrator.php
+++ b/src/AbstractHydrator.php
@@ -89,7 +89,7 @@ abstract class AbstractHydrator implements
      *
      * @param string $name The name of the strategy to register.
      * @param Strategy\StrategyInterface $strategy The strategy to register.
-     * @return HydratorInterface
+     * @return AbstractHydrator
      */
     public function addStrategy($name, Strategy\StrategyInterface $strategy)
     {


### PR DESCRIPTION
It allows IDEs to not warn when addStrategy methods are chained
that hydrator interface don't hav addStrategy method.
