### PR TITLE
Fix: Use class keyword

### DIFF
--- a/test/Aggregate/HydratorListenerTest.php
+++ b/test/Aggregate/HydratorListenerTest.php
@@ -11,9 +11,11 @@ namespace ZendTest\Hydrator\Aggregate;
 
 use PHPUnit_Framework_TestCase;
 use stdClass;
+use Zend\EventManager\EventManagerInterface;
 use Zend\Hydrator\Aggregate\ExtractEvent;
 use Zend\Hydrator\Aggregate\HydrateEvent;
 use Zend\Hydrator\Aggregate\HydratorListener;
+use Zend\Hydrator\HydratorInterface;
 
 /**
  * Unit tests for {@see HydratorListener}
@@ -21,7 +23,7 @@ use Zend\Hydrator\Aggregate\HydratorListener;
 class HydratorListenerTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Zend\Hydrator\HydratorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var HydratorInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $hydrator;
 
@@ -37,7 +39,7 @@ class HydratorListenerTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->hydrator = $this->getMock('Zend\Hydrator\HydratorInterface');
+        $this->hydrator = $this->getMock(HydratorInterface::class);
         $this->listener = new HydratorListener($this->hydrator);
     }
 
@@ -46,7 +48,7 @@ class HydratorListenerTest extends PHPUnit_Framework_TestCase
      */
     public function testAttach()
     {
-        $eventManager = $this->getMock('Zend\EventManager\EventManagerInterface');
+        $eventManager = $this->getMock(EventManagerInterface::class);
 
         $eventManager
             ->expects($this->exactly(2))
@@ -71,7 +73,7 @@ class HydratorListenerTest extends PHPUnit_Framework_TestCase
         $hydrated = new stdClass();
         $data     = ['foo' => 'bar'];
         $event    = $this
-            ->getMockBuilder('Zend\Hydrator\Aggregate\HydrateEvent')
+            ->getMockBuilder(HydrateEvent::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -97,7 +99,7 @@ class HydratorListenerTest extends PHPUnit_Framework_TestCase
         $object = new stdClass();
         $data   = ['foo' => 'bar'];
         $event  = $this
-            ->getMockBuilder('Zend\Hydrator\Aggregate\ExtractEvent')
+            ->getMockBuilder(ExtractEvent::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/test/Filter/OptionalParametersFilterTest.php
+++ b/test/Filter/OptionalParametersFilterTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Hydrator\Filter;
 
+use InvalidArgumentException;
 use Zend\Hydrator\Filter\OptionalParametersFilter;
 
 /**
@@ -62,7 +63,7 @@ class OptionalParametersFilterTest extends \PHPUnit_Framework_TestCase
 
     public function testTriggersExceptionOnUnknownMethod()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
         $this->filter->filter(__CLASS__ . '::' . 'nonExistingMethod');
     }
 

--- a/test/HydratorClosureStrategyTest.php
+++ b/test/HydratorClosureStrategyTest.php
@@ -112,6 +112,6 @@ class HydratorClosureStrategyTest extends \PHPUnit_Framework_TestCase
         $this->hydrator->hydrate($values, $entity);
         $this->assertCount(3, (array) $entity);
 
-        $this->assertInstanceOf('ZendTest\Hydrator\TestAsset\HydratorClosureStrategyEntity', $entity->field3);
+        $this->assertInstanceOf(TestAsset\HydratorClosureStrategyEntity::class, $entity->field3);
     }
 }

--- a/test/HydratorStrategyTest.php
+++ b/test/HydratorStrategyTest.php
@@ -106,7 +106,7 @@ class HydratorStrategyTest extends \PHPUnit_Framework_TestCase
     ) {
         $hydrator = new ClassMethods($underscoreSeparatedKeys);
 
-        $strategy = $this->getMock('Zend\Hydrator\Strategy\StrategyInterface');
+        $strategy = $this->getMock(\Zend\Hydrator\Strategy\StrategyInterface::class);
 
         $entity = new TestAsset\ClassMethodsUnderscore();
         $value = $entity->getFooBar();

--- a/test/HydratorTest.php
+++ b/test/HydratorTest.php
@@ -289,9 +289,9 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $hydrator->addStrategy('default', new DefaultStrategy());
         $hydrator->addStrategy('*', new SerializableStrategy('phpserialize'));
         $default = $hydrator->getStrategy('default');
-        $this->assertEquals(get_class($default), 'Zend\Hydrator\Strategy\DefaultStrategy');
+        $this->assertEquals(get_class($default), DefaultStrategy::class);
         $serializable = $hydrator->getStrategy('*');
-        $this->assertEquals(get_class($serializable), 'Zend\Hydrator\Strategy\SerializableStrategy');
+        $this->assertEquals(get_class($serializable), SerializableStrategy::class);
     }
 
     public function testUseWildStrategyByDefault()

--- a/test/Iterator/HydratingArrayIteratorTest.php
+++ b/test/Iterator/HydratingArrayIteratorTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Hydrator\Iterator;
 
 use ArrayObject;
 use Zend\Hydrator\ArraySerializable;
+use Zend\Hydrator\Exception\InvalidArgumentException;
 use Zend\Hydrator\Iterator\HydratingArrayIterator;
 
 class HydratingArrayIteratorTest extends \PHPUnit_Framework_TestCase
@@ -52,7 +53,7 @@ class HydratingArrayIteratorTest extends \PHPUnit_Framework_TestCase
 
     public function testThrowingInvalidArguementExceptionWhenSettingPrototypeToInvalidClass()
     {
-        $this->setExpectedException('Zend\Hydrator\Exception\InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
         $hydratingIterator = new HydratingArrayIterator(new ArraySerializable(), [], 'not a real class');
     }
 }

--- a/test/Iterator/HydratingIteratorIteratorTest.php
+++ b/test/Iterator/HydratingIteratorIteratorTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Hydrator\Iterator;
 use ArrayIterator;
 use ArrayObject;
 use Zend\Hydrator\ArraySerializable;
+use Zend\Hydrator\Exception\InvalidArgumentException;
 use Zend\Hydrator\Iterator\HydratingIteratorIterator;
 
 class HydratingIteratorIteratorTest extends \PHPUnit_Framework_TestCase
@@ -56,7 +57,7 @@ class HydratingIteratorIteratorTest extends \PHPUnit_Framework_TestCase
 
     public function testThrowingInvalidArguementExceptionWhenSettingPrototypeToInvalidClass()
     {
-        $this->setExpectedException('Zend\Hydrator\Exception\InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
         $hydratingIterator = new HydratingIteratorIterator(
             new ArraySerializable(),
             new ArrayIterator(),

--- a/test/NamingStrategy/CompositeNamingStrategyTest.php
+++ b/test/NamingStrategy/CompositeNamingStrategyTest.php
@@ -22,7 +22,7 @@ class CompositeNamingStrategyTest extends \PHPUnit_Framework_TestCase
     public function testGetSameNameWhenNoNamingStrategyExistsForTheName()
     {
         $compositeNamingStrategy = new CompositeNamingStrategy([
-            'foo' => $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface')
+            'foo' => $this->getMock(NamingStrategyInterface::class)
         ]);
 
         $this->assertEquals('bar', $compositeNamingStrategy->hydrate('bar'));
@@ -32,7 +32,7 @@ class CompositeNamingStrategyTest extends \PHPUnit_Framework_TestCase
     public function testUseDefaultNamingStrategy()
     {
         /* @var $defaultNamingStrategy NamingStrategyInterface|\PHPUnit_Framework_MockObject_MockObject*/
-        $defaultNamingStrategy = $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface');
+        $defaultNamingStrategy = $this->getMock(NamingStrategyInterface::class);
         $defaultNamingStrategy->expects($this->at(0))
             ->method('hydrate')
             ->with('foo')
@@ -43,7 +43,7 @@ class CompositeNamingStrategyTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('foo'));
 
         $compositeNamingStrategy = new CompositeNamingStrategy(
-            ['bar' => $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface')],
+            ['bar' => $this->getMock(NamingStrategyInterface::class)],
             $defaultNamingStrategy
         );
         $this->assertEquals('Foo', $compositeNamingStrategy->hydrate('foo'));
@@ -52,7 +52,7 @@ class CompositeNamingStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testHydrate()
     {
-        $fooNamingStrategy = $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface');
+        $fooNamingStrategy = $this->getMock(NamingStrategyInterface::class);
         $fooNamingStrategy->expects($this->once())
             ->method('hydrate')
             ->with('foo')
@@ -63,7 +63,7 @@ class CompositeNamingStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testExtract()
     {
-        $fooNamingStrategy = $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface');
+        $fooNamingStrategy = $this->getMock(NamingStrategyInterface::class);
         $fooNamingStrategy->expects($this->once())
             ->method('extract')
             ->with('FOO')

--- a/test/NamingStrategy/MapNamingStrategyTest.php
+++ b/test/NamingStrategy/MapNamingStrategyTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Hydrator\NamingStrategy;
 
+use InvalidArgumentException;
 use Zend\Hydrator\NamingStrategy\MapNamingStrategy;
 
 class MapNamingStrategyTest extends \PHPUnit_Framework_TestCase
@@ -34,7 +35,7 @@ class MapNamingStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testSingleMapInvalidValue()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
         new MapNamingStrategy(['foo' => 3.1415]);
     }
 

--- a/test/ObjectPropertyTest.php
+++ b/test/ObjectPropertyTest.php
@@ -39,7 +39,7 @@ class ObjectPropertyTest extends \PHPUnit_Framework_TestCase
      */
     public function testHydratorExtractThrowsExceptionOnNonObjectParameter()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->setExpectedException(BadMethodCallException::class);
         $this->hydrator->extract('thisIsNotAnObject');
     }
 
@@ -48,7 +48,7 @@ class ObjectPropertyTest extends \PHPUnit_Framework_TestCase
      */
     public function testHydratorHydrateThrowsExceptionOnNonObjectParameter()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->setExpectedException(BadMethodCallException::class);
         $this->hydrator->hydrate(['some' => 'data'], 'thisIsNotAnObject');
     }
 

--- a/test/Strategy/BooleanStrategyTest.php
+++ b/test/Strategy/BooleanStrategyTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Hydrator\Strategy;
 
+use Zend\Hydrator\Exception\InvalidArgumentException;
 use Zend\Hydrator\Strategy\BooleanStrategy;
 
 /**
@@ -20,18 +21,18 @@ class BooleanStrategyTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorWithValidInteger()
     {
-        $this->assertInstanceOf('Zend\Hydrator\Strategy\BooleanStrategy', new BooleanStrategy(1, 0));
+        $this->assertInstanceOf(BooleanStrategy::class, new BooleanStrategy(1, 0));
     }
 
     public function testConstructorWithValidString()
     {
-        $this->assertInstanceOf('Zend\Hydrator\Strategy\BooleanStrategy', new BooleanStrategy('true', 'false'));
+        $this->assertInstanceOf(BooleanStrategy::class, new BooleanStrategy('true', 'false'));
     }
 
     public function testExceptionOnWrongTrueValueInConstructor()
     {
         $this->setExpectedException(
-            'Zend\Hydrator\Exception\InvalidArgumentException',
+            InvalidArgumentException::class,
             'Expected int or string as $trueValue.'
         );
 
@@ -41,7 +42,7 @@ class BooleanStrategyTest extends \PHPUnit_Framework_TestCase
     public function testExceptionOnWrongFalseValueInConstructor()
     {
         $this->setExpectedException(
-            'Zend\Hydrator\Exception\InvalidArgumentException',
+            InvalidArgumentException::class,
             'Expected int or string as $falseValue.'
         );
 
@@ -67,7 +68,7 @@ class BooleanStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $hydrator = new BooleanStrategy(1, 0);
 
-        $this->setExpectedException('Zend\Hydrator\Exception\InvalidArgumentException', 'Unable to extract');
+        $this->setExpectedException(InvalidArgumentException::class, 'Unable to extract');
 
         $hydrator->extract(5);
     }
@@ -88,14 +89,14 @@ class BooleanStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testHydrateUnexpectedValueThrowsException()
     {
-        $this->setExpectedException('Zend\Hydrator\Exception\InvalidArgumentException', 'Unexpected value');
+        $this->setExpectedException(InvalidArgumentException::class, 'Unexpected value');
         $hydrator = new BooleanStrategy(1, 0);
         $hydrator->hydrate(2);
     }
 
     public function testHydrateInvalidArgument()
     {
-        $this->setExpectedException('Zend\Hydrator\Exception\InvalidArgumentException', 'Unable to hydrate');
+        $this->setExpectedException(InvalidArgumentException::class, 'Unable to hydrate');
         $hydrator = new BooleanStrategy(1, 0);
         $hydrator->hydrate(new \stdClass());
     }

--- a/test/Strategy/DateTimeFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeFormatterStrategyTest.php
@@ -47,7 +47,7 @@ class DateTimeFormatterStrategyTest extends \PHPUnit_Framework_TestCase
         $strategy = new DateTimeFormatterStrategy();
         $date = $strategy->extract(new \stdClass);
 
-        $this->assertInstanceOf('stdClass', $date);
+        $this->assertInstanceOf(\stdClass::class, $date);
     }
 
     public function testCanHydrateWithInvalidDateTime()
@@ -58,7 +58,7 @@ class DateTimeFormatterStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testAcceptsStringCastableDateTimeFormat()
     {
-        $format = $this->getMock('stdClass', ['__toString']);
+        $format = $this->getMock(\stdClass::class, ['__toString']);
 
         $format->expects($this->once())->method('__toString')->will($this->returnValue('d/m/Y'));
 

--- a/test/Strategy/ExplodeStrategyTest.php
+++ b/test/Strategy/ExplodeStrategyTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Hydrator\Strategy;
 
+use Zend\Hydrator\Strategy\Exception\InvalidArgumentException;
 use Zend\Hydrator\Strategy\ExplodeStrategy;
 
 /**
@@ -40,7 +41,7 @@ class ExplodeStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new ExplodeStrategy();
 
-        $this->setExpectedException('Zend\Hydrator\Strategy\Exception\InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
 
         $strategy->extract('');
     }
@@ -54,14 +55,14 @@ class ExplodeStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testGetExceptionWithEmptyDelimiter()
     {
-        $this->setExpectedException('Zend\Hydrator\Strategy\Exception\InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
 
         new ExplodeStrategy('');
     }
 
     public function testGetExceptionWithInvalidDelimiter()
     {
-        $this->setExpectedException('Zend\Hydrator\Strategy\Exception\InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
 
         new ExplodeStrategy([]);
     }
@@ -80,7 +81,7 @@ class ExplodeStrategyTest extends \PHPUnit_Framework_TestCase
         $strategy = new ExplodeStrategy();
 
         $this->setExpectedException(
-            'Zend\Hydrator\Strategy\Exception\InvalidArgumentException',
+            InvalidArgumentException::class,
             'Zend\Hydrator\Strategy\ExplodeStrategy::hydrate expects argument 1 to be string,'
             . ' array provided instead'
         );
@@ -93,7 +94,7 @@ class ExplodeStrategyTest extends \PHPUnit_Framework_TestCase
         $strategy = new ExplodeStrategy();
 
         $this->setExpectedException(
-            'Zend\Hydrator\Strategy\Exception\InvalidArgumentException',
+            InvalidArgumentException::class,
             'Zend\Hydrator\Strategy\ExplodeStrategy::hydrate expects argument 1 to be string,'
             . ' stdClass provided instead'
         );
@@ -106,7 +107,7 @@ class ExplodeStrategyTest extends \PHPUnit_Framework_TestCase
         $strategy = new ExplodeStrategy();
 
         $this->setExpectedException(
-            'Zend\Hydrator\Strategy\Exception\InvalidArgumentException',
+            InvalidArgumentException::class,
             'Zend\Hydrator\Strategy\ExplodeStrategy::extract expects argument 1 to be array,'
             . ' stdClass provided instead'
         );

--- a/test/Strategy/SerializableStrategyTest.php
+++ b/test/Strategy/SerializableStrategyTest.php
@@ -10,14 +10,16 @@
 namespace ZendTest\Hydrator\Strategy;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Hydrator\Exception\InvalidArgumentException;
 use Zend\Hydrator\Strategy\SerializableStrategy;
+use Zend\Serializer\Adapter\PhpSerialize;
 use Zend\Serializer\Serializer;
 
 class SerializableStrategyTest extends TestCase
 {
     public function testCannotUseBadArgumentSerilizer()
     {
-        $this->setExpectedException('Zend\Hydrator\Exception\InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
         $serializerStrategy = new SerializableStrategy(false);
     }
 
@@ -31,7 +33,7 @@ class SerializableStrategyTest extends TestCase
     public function testUseBadSerilizerString()
     {
         $serializerStrategy = new SerializableStrategy('phpserialize');
-        $this->assertEquals('Zend\Serializer\Adapter\PhpSerialize', get_class($serializerStrategy->getSerializer()));
+        $this->assertEquals(PhpSerialize::class, get_class($serializerStrategy->getSerializer()));
     }
 
     public function testCanSerialize()


### PR DESCRIPTION
This PR
- [x] makes use of the `class` keyword

💁 For reference, see [`composer.json`](https://github.com/zendframework/zend-hydrator/blob/master/composer.json#L16).
