### PR TITLE
Fix: Reduce visibility of setUp()

### DIFF
--- a/test/Aggregate/AggregateHydratorFunctionalTest.php
+++ b/test/Aggregate/AggregateHydratorFunctionalTest.php
@@ -33,7 +33,7 @@ class AggregateHydratorFunctionalTest extends PHPUnit_Framework_TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->hydrator = new AggregateHydrator();
     }

--- a/test/Aggregate/AggregateHydratorTest.php
+++ b/test/Aggregate/AggregateHydratorTest.php
@@ -36,7 +36,7 @@ class AggregateHydratorTest extends PHPUnit_Framework_TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->eventManager = $this->prophesize(EventManager::class);
         $this->hydrator     = new AggregateHydrator();

--- a/test/Aggregate/HydratorListenerTest.php
+++ b/test/Aggregate/HydratorListenerTest.php
@@ -35,7 +35,7 @@ class HydratorListenerTest extends PHPUnit_Framework_TestCase
      *
      * @covers \Zend\Hydrator\Aggregate\HydratorListener::__construct
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->hydrator = $this->getMock('Zend\Hydrator\HydratorInterface');
         $this->listener = new HydratorListener($this->hydrator);

--- a/test/ArraySerializableTest.php
+++ b/test/ArraySerializableTest.php
@@ -29,7 +29,7 @@ class ArraySerializableTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->hydrator = new ArraySerializable();
     }

--- a/test/ClassMethodsTest.php
+++ b/test/ClassMethodsTest.php
@@ -32,7 +32,7 @@ class ClassMethodsTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->hydrator = new ClassMethods();
     }

--- a/test/DelegatingHydratorTest.php
+++ b/test/DelegatingHydratorTest.php
@@ -40,7 +40,7 @@ class DelegatingHydratorTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->hydrators = $this->prophesize(ContainerInterface::class);
         $this->hydrator = new DelegatingHydrator($this->hydrators->reveal());

--- a/test/Filter/OptionalParametersFilterTest.php
+++ b/test/Filter/OptionalParametersFilterTest.php
@@ -26,7 +26,7 @@ class OptionalParametersFilterTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->filter = new OptionalParametersFilter();
     }

--- a/test/HydratorClosureStrategyTest.php
+++ b/test/HydratorClosureStrategyTest.php
@@ -21,7 +21,7 @@ class HydratorClosureStrategyTest extends \PHPUnit_Framework_TestCase
      */
     private $hydrator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->hydrator = new ObjectProperty();
     }

--- a/test/HydratorObjectPropertyTest.php
+++ b/test/HydratorObjectPropertyTest.php
@@ -13,7 +13,7 @@ use Zend\Hydrator\ObjectProperty;
 
 class HydratorObjectPropertyTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->hydrator = new ObjectProperty();
     }

--- a/test/HydratorStrategyTest.php
+++ b/test/HydratorStrategyTest.php
@@ -21,7 +21,7 @@ class HydratorStrategyTest extends \PHPUnit_Framework_TestCase
      */
     private $hydrator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->hydrator = new ClassMethods();
     }

--- a/test/HydratorTest.php
+++ b/test/HydratorTest.php
@@ -61,7 +61,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
      */
     protected $reflection;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->classMethodsCamelCase = new ClassMethodsCamelCase();
         $this->classMethodsTitleCase = new ClassMethodsTitleCase();

--- a/test/ReflectionTest.php
+++ b/test/ReflectionTest.php
@@ -28,7 +28,7 @@ class ReflectionTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->hydrator = new Reflection();
     }


### PR DESCRIPTION
This PR
- [x] reduces the visibility of `setUp()` from `public` to `protected`

💁 This is the visibility as declared on the parent, there's no need to increase it.
