### PR TITLE
Fix: Typo in namespace

### DIFF
--- a/test/HydratorObjectPropertyTest.php
+++ b/test/HydratorObjectPropertyTest.php
@@ -7,7 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace ZendTest\Hdyrator;
+namespace ZendTest\Hydrator;
 
 use Zend\Hydrator\ObjectProperty;
 


### PR DESCRIPTION
This PR
- [x] fixes a typo in a namespace
