### PR TITLE
Fix: Typos in method names and docblocks

### DIFF
--- a/src/Filter/NumberOfParameterFilter.php
+++ b/src/Filter/NumberOfParameterFilter.php
@@ -16,7 +16,7 @@ use Zend\Hydrator\Exception\InvalidArgumentException;
 class NumberOfParameterFilter implements FilterInterface
 {
     /**
-     * The number of parameters beeing accepted
+     * The number of parameters being accepted
      * @var int
      */
     protected $numberOfParameters = null;

--- a/src/NamingStrategy/MapNamingStrategy.php
+++ b/src/NamingStrategy/MapNamingStrategy.php
@@ -40,7 +40,7 @@ class MapNamingStrategy implements NamingStrategyInterface
     }
 
     /**
-     * Safelly flip mapping array.
+     * Safely flip mapping array.
      *
      * @param  array                    $array Array to flip
      * @return array                    Flipped array

--- a/test/Iterator/HydratingArrayIteratorTest.php
+++ b/test/Iterator/HydratingArrayIteratorTest.php
@@ -50,7 +50,7 @@ class HydratingArrayIteratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new ArrayObject($data[0]), $hydratingIterator->current());
     }
 
-    public function testThrowingInvalidArguementExceptionWhenSettingPrototypeToInvalidClass()
+    public function testThrowingInvalidArgumentExceptionWhenSettingPrototypeToInvalidClass()
     {
         $this->setExpectedException('Zend\Hydrator\Exception\InvalidArgumentException');
         $hydratingIterator = new HydratingArrayIterator(new ArraySerializable(), [], 'not a real class');

--- a/test/Iterator/HydratingIteratorIteratorTest.php
+++ b/test/Iterator/HydratingIteratorIteratorTest.php
@@ -54,7 +54,7 @@ class HydratingIteratorIteratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new ArrayObject($data[0]), $hydratingIterator->current());
     }
 
-    public function testThrowingInvalidArguementExceptionWhenSettingPrototypeToInvalidClass()
+    public function testThrowingInvalidArgumentExceptionWhenSettingPrototypeToInvalidClass()
     {
         $this->setExpectedException('Zend\Hydrator\Exception\InvalidArgumentException');
         $hydratingIterator = new HydratingIteratorIterator(

--- a/test/Strategy/SerializableStrategyTest.php
+++ b/test/Strategy/SerializableStrategyTest.php
@@ -15,20 +15,20 @@ use Zend\Serializer\Serializer;
 
 class SerializableStrategyTest extends TestCase
 {
-    public function testCannotUseBadArgumentSerilizer()
+    public function testCannotUseBadArgumentSerializer()
     {
         $this->setExpectedException('Zend\Hydrator\Exception\InvalidArgumentException');
         $serializerStrategy = new SerializableStrategy(false);
     }
 
-    public function testUseBadSerilizerObject()
+    public function testUseBadSerializerObject()
     {
         $serializer = Serializer::factory('phpserialize');
         $serializerStrategy = new SerializableStrategy($serializer);
         $this->assertEquals($serializer, $serializerStrategy->getSerializer());
     }
 
-    public function testUseBadSerilizerString()
+    public function testUseBadSerializerString()
     {
         $serializerStrategy = new SerializableStrategy('phpserialize');
         $this->assertEquals('Zend\Serializer\Adapter\PhpSerialize', get_class($serializerStrategy->getSerializer()));


### PR DESCRIPTION
This PR
- [x] fixes typos in (test) method names and docblocks
