### PR TITLE
Fix: Declare field otherwise declared dynamically

### DIFF
--- a/test/HydratorObjectPropertyTest.php
+++ b/test/HydratorObjectPropertyTest.php
@@ -13,6 +13,11 @@ use Zend\Hydrator\ObjectProperty;
 
 class HydratorObjectPropertyTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ObjectProperty
+     */
+    private $hydrator;
+
     public function setUp()
     {
         $this->hydrator = new ObjectProperty();


### PR DESCRIPTION
This PR
- [x] declares a field otherwise declared dynamically
