### PR TITLE
Fix: Update composer.lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ notifications:
 before_install:
   - travis_retry composer self-update
   - if [[ $TRAVIS_PHP_VERSION != "hhvm" && $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini ; fi
+  - composer validate
 
 install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cadb5798d25c53b25e14a550d37e654a",
-    "content-hash": "af95815a16c050b470fd3013669a2deb",
+    "hash": "b5a29f427a3eeba198c38045128ba936",
+    "content-hash": "429805166826c21eaa3e410bc9698e51",
     "packages": [
         {
             "name": "zendframework/zend-stdlib",


### PR DESCRIPTION
This PR
- [x] runs `composer validate` on Travis
- [x] runs `composer update --lock`

💁 Running

```
$ composer validate
```

on current `master` yields

```
./composer.json is valid
The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update`.
```
