### PR TITLE
ClassMethods: Add switch to prevent the call of __call as setter

### DIFF
--- a/src/ClassMethods.php
+++ b/src/ClassMethods.php
@@ -38,6 +38,14 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
     protected $underscoreSeparatedKeys = true;
 
     /**
+     * Flag defining whether to check the setter method with method_exists to prevent the
+     * hydrator from calling __call during hydration
+     *
+     * @var bool
+     */
+    protected $methodExistsCheck = false;
+
+    /**
      * @var Filter\FilterInterface
      */
     private $callableMethodFilter;
@@ -46,10 +54,11 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
      * Define if extract values will use camel case or name with underscore
      * @param bool|array $underscoreSeparatedKeys
      */
-    public function __construct($underscoreSeparatedKeys = true)
+    public function __construct($underscoreSeparatedKeys = true, $methodExistsCheck = false)
     {
         parent::__construct();
         $this->setUnderscoreSeparatedKeys($underscoreSeparatedKeys);
+        $this->setMethodExistsCheck($methodExistsCheck);
 
         $this->callableMethodFilter = new Filter\OptionalParametersFilter();
 
@@ -80,6 +89,9 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
         if (isset($options['underscoreSeparatedKeys'])) {
             $this->setUnderscoreSeparatedKeys($options['underscoreSeparatedKeys']);
         }
+        if (isset($options['methodExistsCheck'])) {
+            $this->setMethodExistsCheck($options['methodExistsCheck']);
+        }
 
         return $this;
     }
@@ -107,6 +119,25 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
     public function getUnderscoreSeparatedKeys()
     {
         return $this->underscoreSeparatedKeys;
+    }
+
+    /**
+     * @param  bool      $methodExistsCheck
+     * @return ClassMethods
+     */
+    public function setMethodExistsCheck($methodExistsCheck)
+    {
+        $this->methodExistsCheck = (bool) $methodExistsCheck;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getMethodExistsCheck()
+    {
+        return $this->methodExistsCheck;
     }
 
     /**
@@ -206,6 +237,7 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
                 $setterName = 'set' . ucfirst($this->hydrateName($property, $data));
 
                 $this->hydrationMethodsCache[$propertyFqn] = is_callable([$object, $setterName])
+                    && (!$this->methodExistsCheck || method_exists($object, $setterName))
                     ? $setterName
                     : false;
             }

--- a/test/HydratorTest.php
+++ b/test/HydratorTest.php
@@ -485,4 +485,14 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($data['foo'], 'bar');
     }
+
+    public function testHydratorClassMethodsWithMagicMethodSetterAndMethodExistsCheck()
+    {
+        $hydrator = new ClassMethods(false, true);
+        $object = new ClassMethodsMagicMethodSetter();
+        $hydrator->hydrate(['foo' => 'bar'], $object);
+        $data = $hydrator->extract($object);
+
+        $this->assertNull($data['foo']);
+    }
 }


### PR DESCRIPTION
Enable/disable the use of magic __call method during hydration by setting a flag to true/false (allows __call by default because of BC)

See also: doctrine/DoctrineModule#560