### PR TITLE
Bugfix: ClassMethods strategies tied to original name 

### DIFF
--- a/src/AbstractHydrator.php
+++ b/src/AbstractHydrator.php
@@ -59,6 +59,11 @@ abstract class AbstractHydrator implements
     {
         if (isset($this->strategies[$name])) {
             return $this->strategies[$name];
+        } elseif ($this->hasNamingStrategy() &&
+            ($hydrated = $this->getNamingStrategy()->hydrate($name)) &&
+            isset($this->strategies[$hydrated])
+        ) {
+            return $this->strategies[$hydrated];
         }
 
         if (!isset($this->strategies['*'])) {
@@ -80,8 +85,17 @@ abstract class AbstractHydrator implements
      */
     public function hasStrategy($name)
     {
-        return array_key_exists($name, $this->strategies)
-               || array_key_exists('*', $this->strategies);
+        if (array_key_exists($name, $this->strategies)) {
+            return true;
+        }
+
+        if ($this->hasNamingStrategy() &&
+            array_key_exists($this->getNamingStrategy()->hydrate($name), $this->strategies)
+        ) {
+            return true;
+        }
+
+        return array_key_exists('*', $this->strategies);
     }
 
     /**

--- a/test/ArraySerializableTest.php
+++ b/test/ArraySerializableTest.php
@@ -21,6 +21,8 @@ use ZendTest\Hydrator\TestAsset\ArraySerializable as ArraySerializableAsset;
  */
 class ArraySerializableTest extends \PHPUnit_Framework_TestCase
 {
+    use HydratorTestTrait;
+
     /**
      * @var ArraySerializable
      */

--- a/test/ClassMethodsTest.php
+++ b/test/ClassMethodsTest.php
@@ -24,6 +24,8 @@ use ZendTest\Hydrator\TestAsset\ArraySerializable;
  */
 class ClassMethodsTest extends \PHPUnit_Framework_TestCase
 {
+    use HydratorTestTrait;
+
     /**
      * @var ClassMethods
      */

--- a/test/HydratorTestTrait.php
+++ b/test/HydratorTestTrait.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Hydrator;
+
+use ZendTest\Hydrator\TestAsset\SimpleEntity;
+
+trait HydratorTestTrait
+{
+    public function testHydrateWithNamingStrategyAndStrategy()
+    {
+        $namingStrategy = $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface');
+        $namingStrategy
+            ->expects($this->once())
+            ->method('hydrate')
+            ->with($this->anything())
+            ->will($this->returnValue('value'))
+        ;
+
+        $strategy = $this->getMock('Zend\Hydrator\Strategy\StrategyInterface');
+        $strategy
+            ->expects($this->once())
+            ->method('hydrate')
+            ->with($this->anything())
+            ->will($this->returnValue('hydrate'))
+        ;
+
+        $this->hydrator->setNamingStrategy($namingStrategy);
+        $this->hydrator->addStrategy('value', $strategy);
+
+        $entity = $this->hydrator->hydrate(['foo_bar_baz' => 'blub'], new SimpleEntity());
+        $this->assertSame(
+            'hydrate',
+            $entity->getValue(),
+            sprintf('Hydrator: %s', get_class($this->hydrator))
+        );
+    }
+}

--- a/test/HydratorTestTrait.php
+++ b/test/HydratorTestTrait.php
@@ -17,7 +17,7 @@ trait HydratorTestTrait
     {
         $namingStrategy = $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface');
         $namingStrategy
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('hydrate')
             ->with($this->anything())
             ->will($this->returnValue('value'))
@@ -25,7 +25,7 @@ trait HydratorTestTrait
 
         $strategy = $this->getMock('Zend\Hydrator\Strategy\StrategyInterface');
         $strategy
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('hydrate')
             ->with($this->anything())
             ->will($this->returnValue('hydrate'))

--- a/test/ObjectPropertyTest.php
+++ b/test/ObjectPropertyTest.php
@@ -21,6 +21,8 @@ use ZendTest\Hydrator\TestAsset\ObjectProperty as ObjectPropertyTestAsset;
  */
 class ObjectPropertyTest extends \PHPUnit_Framework_TestCase
 {
+    use HydratorTestTrait;
+
     /**
      * @var ObjectProperty
      */

--- a/test/ReflectionTest.php
+++ b/test/ReflectionTest.php
@@ -20,6 +20,8 @@ use Zend\Hydrator\Reflection;
  */
 class ReflectionTest extends \PHPUnit_Framework_TestCase
 {
+    use HydratorTestTrait;
+
     /**
      * @var Reflection
      */

--- a/test/TestAsset/SimpleEntity.php
+++ b/test/TestAsset/SimpleEntity.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Hydrator\TestAsset;
+
+class SimpleEntity
+{
+    public $value;
+
+    /**
+     * @param  mixed $value
+     * @return void
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Exchange internal values from provided array
+     *
+     * @param  array $array
+     * @return void
+     */
+    public function exchangeArray(array $array)
+    {
+        if (array_key_exists('value', $array)) {
+            $this->setValue($array['value']);
+        }
+    }
+
+    /**
+     * Return an array representation of the object
+     *
+     * @return array
+     */
+    public function getArrayCopy()
+    {
+        return ['value' => $this->getValue()];
+    }
+}


### PR DESCRIPTION
All hydrators hydrate values by calling `$this->hydrateValue($this->hydrateName($originalName, $data), $value, $data)` _(simplified)_.

Only ClassMethods calls `hydrateValue` with the original array key passed to `hydrate`: `$this->hydrateValue($originalName, $value, $data)` _(simplified)_

- [x] First commit: Demonstration test case
- [x] Second commit: Bugfix