### PR TITLE
Enhancement: Implement CollectionStrategy

### DIFF
--- a/src/Strategy/CollectionStrategy.php
+++ b/src/Strategy/CollectionStrategy.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Hydrator\Strategy;
+
+use Zend\Hydrator\HydratorInterface;
+use Zend\Hydrator\Exception;
+
+class CollectionStrategy implements StrategyInterface
+{
+    /**
+     * @var HydratorInterface
+     */
+    private $objectHydrator;
+
+    /**
+     * @var string
+     */
+    private $objectClassName;
+
+    /**
+     * @param HydratorInterface $objectHydrator
+     * @param string $objectClassName
+     *
+     * @throws Exception\InvalidArgumentException
+     */
+    public function __construct(HydratorInterface $objectHydrator, $objectClassName)
+    {
+        if (!\is_string($objectClassName) || !\class_exists($objectClassName)) {
+            throw new Exception\InvalidArgumentException(\sprintf(
+               'Object class name needs to the name of an existing class, got "%s" instead.',
+               \is_object($objectClassName) ? \get_class($objectClassName) : \gettype($objectClassName)
+           ));
+        }
+
+        $this->objectHydrator = $objectHydrator;
+        $this->objectClassName = $objectClassName;
+    }
+
+    /**
+     * Converts the given value so that it can be extracted by the hydrator.
+     *
+     * @param array $value The original value.
+     * @throws Exception\InvalidArgumentException
+     * @return mixed Returns the value that should be extracted.
+     */
+    public function extract($value)
+    {
+        if (!\is_array($value)) {
+            throw new Exception\InvalidArgumentException(\sprintf(
+               'Value needs to be an array, got "%s" instead.',
+               \is_object($value) ? \get_class($value) : \gettype($value)
+            ));
+        }
+
+        return \array_map(function ($object) {
+            if (!$object instanceof $this->objectClassName) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                   'Value needs to be an instance of "%s", got "%s" instead.',
+                   $this->objectClassName,
+                   \is_object($object) ? \get_class($object) : \gettype($object)
+                ));
+            }
+
+            return $this->objectHydrator->extract($object);
+        }, $value);
+    }
+
+    /**
+     * Converts the given value so that it can be hydrated by the hydrator.
+     *
+     * @param array $value The original value.
+     * @throws Exception\InvalidArgumentException
+     * @return mixed Returns the value that should be hydrated.
+     */
+    public function hydrate($value)
+    {
+        if (!\is_array($value)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+               'Value needs to be an array, got "%s" instead.',
+               \is_object($value) ? \get_class($value) : \gettype($value)
+            ));
+        }
+
+        $reflection = new \ReflectionClass($this->objectClassName);
+
+        return \array_map(function ($data) use ($reflection) {
+            return $this->objectHydrator->hydrate(
+                $data,
+                $reflection->newInstanceWithoutConstructor()
+            );
+        }, $value);
+    }
+}

--- a/test/Strategy/CollectionStrategyTest.php
+++ b/test/Strategy/CollectionStrategyTest.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Hydrator\Strategy;
+
+use Zend\Hydrator\HydratorInterface;
+use Zend\Hydrator\Exception;
+use Zend\Hydrator\Reflection;
+use Zend\Hydrator\Strategy\CollectionStrategy;
+use Zend\Hydrator\Strategy\StrategyInterface;
+use ZendTest\Hydrator\TestAsset;
+
+/**
+ * Tests for {@see CollectionStrategy}
+ *
+ * @covers \Zend\Hydrator\Strategy\CollectionStrategy
+ */
+class CollectionStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImplementsStrategyInterface()
+    {
+        $reflection = new \ReflectionClass(CollectionStrategy::class);
+
+        $this->assertTrue($reflection->implementsInterface(StrategyInterface::class), \sprintf(
+            'Failed to assert that "%s" implements "%s"',
+            CollectionStrategy::class,
+            StrategyInterface::class
+        ));
+    }
+
+    /**
+     * @dataProvider providerInvalidObjectClassName
+     *
+     * @param mixed $objectClassName
+     */
+    public function testConstructorRejectsInvalidObjectClassName($objectClassName)
+    {
+        $this->setExpectedException(Exception\InvalidArgumentException::class, \sprintf(
+            'Object class name needs to the name of an existing class, got "%s" instead.',
+            \is_object($objectClassName) ? \get_class($objectClassName) : \gettype($objectClassName)
+        ));
+
+        new CollectionStrategy(
+            $this->createHydratorMock(),
+           $objectClassName
+        );
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidObjectClassName()
+    {
+        $values = [
+            'array' => [],
+            'boolean-false' => false,
+            'boolean-true' => true,
+            'float' => \mt_rand() / \mt_getrandmax(),
+            'integer' => \mt_rand(),
+            'null' => null,
+            'object' => new \stdClass(),
+            'resource' => \fopen(__FILE__, 'r'),
+            'string-non-existent-class' => 'FooBarBaz9000',
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [
+                $value,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider providerInvalidValueForExtraction
+     *
+     * @param mixed $value
+     */
+    public function testExtractRejectsInvalidValue($value)
+    {
+        $strategy = new CollectionStrategy(
+            $this->createHydratorMock(),
+            TestAsset\User::class
+        );
+
+        $this->setExpectedException(Exception\InvalidArgumentException::class, \sprintf(
+            'Value needs to be an array, got "%s" instead.',
+            \is_object($value) ? \get_class($value) : \gettype($value)
+        ));
+
+        $strategy->extract($value);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidValueForExtraction()
+    {
+        $values = [
+            'boolean-false' => false,
+            'boolean-true' => true,
+            'float' => \mt_rand() / \mt_getrandmax(),
+            'integer' => \mt_rand(),
+            'null' => null,
+            'object' => new \stdClass(),
+            'resource' => \fopen(__FILE__, 'r'),
+            'string-non-existent-class' => 'FooBarBaz9000',
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [
+                $value,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider providerInvalidObjectForExtraction
+     *
+     * @param mixed $object
+     */
+    public function testExtractRejectsInvalidObject($object)
+    {
+        $value = [
+            $object,
+        ];
+
+        $strategy = new CollectionStrategy(
+            $this->createHydratorMock(),
+            TestAsset\User::class
+        );
+
+        $this->setExpectedException(Exception\InvalidArgumentException::class, \sprintf(
+            'Value needs to be an instance of "%s", got "%s" instead.',
+            TestAsset\User::class,
+            \is_object($object) ? \get_class($object) : \gettype($object)
+        ));
+
+        $strategy->extract($value);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidObjectForExtraction()
+    {
+        $values = [
+            'boolean-false' => false,
+            'boolean-true' => true,
+            'float' => \mt_rand() / \mt_getrandmax(),
+            'integer' => \mt_rand(),
+            'null' => null,
+            'object-but-not-instance-of-object-class' => new \stdClass(),
+            'resource' => \fopen(__FILE__, 'r'),
+            'string-non-existent-class' => 'FooBarBaz9000',
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [
+                $value,
+            ];
+        }
+    }
+
+    public function testExtractUsesHydratorToExtractValues()
+    {
+        $value = [
+            new TestAsset\User(),
+            new TestAsset\User(),
+            new TestAsset\User(),
+        ];
+
+        $extraction = function (TestAsset\User $value) {
+            return \spl_object_hash($value);
+        };
+
+        $hydrator = $this->createHydratorMock();
+
+        $hydrator
+            ->expects($this->exactly(\count($value)))
+            ->method('extract')
+            ->willReturnCallback($extraction);
+
+        $strategy = new CollectionStrategy(
+            $hydrator,
+            TestAsset\User::class
+        );
+
+        $expected = \array_map(
+            $extraction,
+            $value
+        );
+
+        $this->assertSame($expected, $strategy->extract($value));
+    }
+
+    /**
+     * @dataProvider providerInvalidValueForHydration
+     *
+     * @param mixed $value
+     */
+    public function testHydrateRejectsInvalidValue($value)
+    {
+        $strategy = new CollectionStrategy(
+            $this->createHydratorMock(),
+            TestAsset\User::class
+        );
+
+        $this->setExpectedException(Exception\InvalidArgumentException::class, \sprintf(
+            'Value needs to be an array, got "%s" instead.',
+            \is_object($value) ? \get_class($value) : \gettype($value)
+        ));
+
+        $strategy->hydrate($value);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidValueForHydration()
+    {
+        $values = [
+            'boolean-false' => false,
+            'boolean-true' => true,
+            'float' => \mt_rand() / \mt_getrandmax(),
+            'integer' => \mt_rand(),
+            'null' => null,
+            'object' => new \stdClass(),
+            'resource' => \fopen(__FILE__, 'r'),
+            'string-non-existent-class' => 'FooBarBaz9000',
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [
+                $value,
+            ];
+        }
+    }
+
+    public function testHydrateUsesHydratorToHydrateValues()
+    {
+        $value = [
+            [
+                'name' => 'Suzie Q.',
+            ],
+            [
+                'name' => 'John Doe',
+            ],
+        ];
+
+        $hydration = function ($data) {
+            static $hydrator;
+
+            if (null === $hydrator) {
+                $hydrator = new Reflection();
+            }
+
+            return $hydrator->hydrate(
+                $data,
+                new TestAsset\User()
+            );
+        };
+
+        $hydrator = $this->createHydratorMock();
+
+        $hydrator
+            ->expects($this->exactly(\count($value)))
+            ->method('hydrate')
+            ->willReturnCallback($hydration);
+
+        $strategy = new CollectionStrategy(
+            $hydrator,
+            TestAsset\User::class
+        );
+
+        $expected = \array_map(
+            $hydration,
+            $value
+        );
+
+        $this->assertEquals($expected, $strategy->hydrate($value));
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|HydratorInterface
+     */
+    private function createHydratorMock()
+    {
+        return $this->getMock(HydratorInterface::class);
+    }
+}

--- a/test/TestAsset/User.php
+++ b/test/TestAsset/User.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Hydrator\TestAsset;
+
+final class User
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @return string
+     */
+    public function name()
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements a `CollectionStrategy`

💁‍♂️ The idea is to turn what would otherwise need implementation in user land code into a generic strategy, which can then be used like this, for example:

```php
<?php

namespace Localheinz\Hydrator;

use Zend\Hydrator\HydratorInterface;
use Zend\Hydrator\Reflection;
use Zend\Hydrator\Strategy;

final class UserGroupHydrator implements HydratorInterface
{
    /**
     * @var Reflection
     */
    private $hydrator;

    public function __construct(Strategy\StrategyInterface $resultsStrategy = null, Reflection $hydrator = null)
    {
        $this->hydrator = $hydrator ?: new Reflection();

        $this->hydrator->addStrategy('users', new Strategy\CollectionStrategy(
            new Reflection(),
            User::class
        ));
    }

    public function extract($object)
    {
        throw new \BadMethodCallException('Extraction is not supported');
    }

    /**
     * @param array $data
     * @param User  $object
     *
     * @throws \InvalidArgumentException
     *
     * @return UserGroup
     */
    public function hydrate(array $data, $object)
    {
        if (!$object instanceof UserGroup) {
            throw new \InvalidArgumentException(\sprintf(
                'Value needs to be an array, got "%s" instead.',
                \is_object($object) ? \get_class($object) : \gettype($object)
            ));
        }

        return $this->hydrator->hydrate(
            $data,
            $object
        );
    }
}
```
