### PR TITLE
spelling fixes

### DIFF
--- a/doc/book/strategy.md
+++ b/doc/book/strategy.md
@@ -112,7 +112,7 @@ conversion of values.
 ### Zend\\Hydrator\\Strategy\\ExplodeStrategy 
 
 This strategy is a wrapper around PHP's `implode()` and `explode()` functions.
-The delemiter and a limit can be provided to the constructor; the limit will
+The delimiter and a limit can be provided to the constructor; the limit will
 only be used for `extract` operations.
 
 ### Zend\\Hydrator\\Strategy\\SerializableStrategy

--- a/src/Filter/NumberOfParameterFilter.php
+++ b/src/Filter/NumberOfParameterFilter.php
@@ -16,7 +16,7 @@ use Zend\Hydrator\Exception\InvalidArgumentException;
 class NumberOfParameterFilter implements FilterInterface
 {
     /**
-     * The number of parameters beeing accepted
+     * The number of parameters being accepted
      * @var int
      */
     protected $numberOfParameters = null;


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.