### PR TITLE
Ensure `hydrators` config is honored in non-zend-mvc contexts

### DIFF
--- a/src/HydratorPluginManagerFactory.php
+++ b/src/HydratorPluginManagerFactory.php
@@ -8,6 +8,7 @@
 namespace Zend\Hydrator;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Config;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -27,7 +28,30 @@ class HydratorPluginManagerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
-        return new HydratorPluginManager($container, $options ?: []);
+        $pluginManager = new HydratorPluginManager($container, $options ?: []);
+
+        // If this is in a zend-mvc application, the ServiceListener will inject
+        // merged configuration during bootstrap.
+        if ($container->has('ServiceListener')) {
+            return $pluginManager;
+        }
+
+        // If we do not have a config service, nothing more to do
+        if (! $container->has('config')) {
+            return $pluginManager;
+        }
+
+        $config = $container->get('config');
+
+        // If we do not have hydrators configuration, nothing more to do
+        if (! isset($config['hydrators']) || ! is_array($config['hydrators'])) {
+            return $pluginManager;
+        }
+
+        // Wire service configuration for hydrators
+        (new Config($config['hydrators']))->configureServiceManager($pluginManager);
+
+        return $pluginManager;
     }
 
     /**


### PR DESCRIPTION
Per https://discourse.zendframework.com/t/validatormanager-not-calling-custom-validator-factory/109/5?u=matthew the `hydrators` config key is not honored currently unless the application is within a zend-mvc context. This is due to the fact that `Zend\Hydrator\Module` wires configuration for the `Zend\ModuleManager\Listener\ServiceListener` in order to push merged service configuration into the plugin during bootstrap; no similar logic is available when not in a zend-mvc context, however.

This patch fixes that situation by modifying the `HydratorPluginManagerFactory` to do the following:

- If a `ServiceListener` service exists, it returns the plugin manager immediately (old behavior).
- Otherwise, it checks for the `config` service, and, if found, a `hydrators` key with an array value. When found, it feeds that value to a `Zend\ServiceManager\Config` instance and uses that to configure the plugin manager before returning it.