### PR TITLE
Backporting Issue 46 Fix

### DIFF
--- a/src/AbstractHydrator.php
+++ b/src/AbstractHydrator.php
@@ -59,6 +59,11 @@ abstract class AbstractHydrator implements
     {
         if (isset($this->strategies[$name])) {
             return $this->strategies[$name];
+        } elseif ($this->hasNamingStrategy() &&
+            ($hydrated = $this->getNamingStrategy()->hydrate($name)) &&
+            isset($this->strategies[$hydrated])
+        ) {
+            return $this->strategies[$hydrated];
         }
 
         if (!isset($this->strategies['*'])) {
@@ -80,8 +85,17 @@ abstract class AbstractHydrator implements
      */
     public function hasStrategy($name)
     {
-        return array_key_exists($name, $this->strategies)
-               || array_key_exists('*', $this->strategies);
+        if (array_key_exists($name, $this->strategies)) {
+            return true;
+        }
+
+        if ($this->hasNamingStrategy() &&
+            array_key_exists($this->getNamingStrategy()->hydrate($name), $this->strategies)
+        ) {
+            return true;
+        }
+
+        return array_key_exists('*', $this->strategies);
     }
 
     /**

--- a/test/ArraySerializableTest.php
+++ b/test/ArraySerializableTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Hydrator;
+
+use Zend\Hydrator\Exception\BadMethodCallException;
+use Zend\Hydrator\ArraySerializable;
+use ZendTest\Hydrator\TestAsset\ArraySerializable as ArraySerializableAsset;
+
+/**
+ * Unit tests for {@see ArraySerializable}
+ *
+ * @covers \Zend\Hydrator\ArraySerializable
+ */
+class ArraySerializableTest extends \PHPUnit_Framework_TestCase
+{
+    use HydratorTestTrait;
+
+    /**
+     * @var ArraySerializable
+     */
+    protected $hydrator;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        $this->hydrator = new ArraySerializable();
+    }
+
+    /**
+     * Verify that we get an exception when trying to extract on a non-object
+     */
+    public function testHydratorExtractThrowsExceptionOnNonObjectParameter()
+    {
+        $this->setExpectedException(
+            BadMethodCallException::class,
+            'Zend\Hydrator\ArraySerializable::extract expects the provided object to implement getArrayCopy()'
+        );
+        $this->hydrator->extract('thisIsNotAnObject');
+    }
+
+    /**
+     * Verify that we get an exception when trying to hydrate a non-object
+     */
+    public function testHydratorHydrateThrowsExceptionOnNonObjectParameter()
+    {
+        $this->setExpectedException(
+            BadMethodCallException::class,
+            'Zend\Hydrator\ArraySerializable::hydrate expects the provided object to implement'
+            . ' exchangeArray() or populate()'
+        );
+        $this->hydrator->hydrate(['some' => 'data'], 'thisIsNotAnObject');
+    }
+
+    /**
+     * Verifies that we can extract from an ArraySerializableInterface
+     */
+    public function testCanExtractFromArraySerializableObject()
+    {
+        $this->assertSame(
+            [
+                'foo'   => 'bar',
+                'bar'   => 'foo',
+                'blubb' => 'baz',
+                'quo'   => 'blubb',
+            ],
+            $this->hydrator->extract(new ArraySerializableAsset())
+        );
+    }
+
+    /**
+     * Verifies we can hydrate an ArraySerializableInterface
+     */
+    public function testCanHydrateToArraySerializableObject()
+    {
+        $data = [
+            'foo'   => 'bar1',
+            'bar'   => 'foo1',
+            'blubb' => 'baz1',
+            'quo'   => 'blubb1',
+        ];
+        $object = $this->hydrator->hydrate($data, new ArraySerializableAsset());
+
+        $this->assertSame($data, $object->getArrayCopy());
+    }
+}

--- a/test/ClassMethodsTest.php
+++ b/test/ClassMethodsTest.php
@@ -22,6 +22,8 @@ use ZendTest\Hydrator\TestAsset\ArraySerializable;
  */
 class ClassMethodsTest extends \PHPUnit_Framework_TestCase
 {
+    use HydratorTestTrait;
+
     /**
      * @var ClassMethods
      */

--- a/test/HydratorTestTrait.php
+++ b/test/HydratorTestTrait.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Hydrator;
+
+use ZendTest\Hydrator\TestAsset\SimpleEntity;
+
+trait HydratorTestTrait
+{
+    public function testHydrateWithNamingStrategyAndStrategy()
+    {
+        $namingStrategy = $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface');
+        $namingStrategy
+            ->expects($this->once())
+            ->method('hydrate')
+            ->with($this->anything())
+            ->will($this->returnValue('value'))
+        ;
+
+        $strategy = $this->getMock('Zend\Hydrator\Strategy\StrategyInterface');
+        $strategy
+            ->expects($this->once())
+            ->method('hydrate')
+            ->with($this->anything())
+            ->will($this->returnValue('hydrate'))
+        ;
+
+        $this->hydrator->setNamingStrategy($namingStrategy);
+        $this->hydrator->addStrategy('value', $strategy);
+
+        $entity = $this->hydrator->hydrate(['foo_bar_baz' => 'blub'], new SimpleEntity());
+        $this->assertSame(
+            'hydrate',
+            $entity->getValue(),
+            sprintf('Hydrator: %s', get_class($this->hydrator))
+        );
+    }
+}

--- a/test/HydratorTestTrait.php
+++ b/test/HydratorTestTrait.php
@@ -17,7 +17,7 @@ trait HydratorTestTrait
     {
         $namingStrategy = $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface');
         $namingStrategy
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('hydrate')
             ->with($this->anything())
             ->will($this->returnValue('value'))
@@ -25,7 +25,7 @@ trait HydratorTestTrait
 
         $strategy = $this->getMock('Zend\Hydrator\Strategy\StrategyInterface');
         $strategy
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('hydrate')
             ->with($this->anything())
             ->will($this->returnValue('hydrate'))

--- a/test/ObjectPropertyTest.php
+++ b/test/ObjectPropertyTest.php
@@ -21,6 +21,8 @@ use ZendTest\Hydrator\TestAsset\ObjectProperty as ObjectPropertyTestAsset;
  */
 class ObjectPropertyTest extends \PHPUnit_Framework_TestCase
 {
+    use HydratorTestTrait;
+
     /**
      * @var ObjectProperty
      */

--- a/test/ReflectionTest.php
+++ b/test/ReflectionTest.php
@@ -19,6 +19,8 @@ use Zend\Hydrator\Reflection;
  */
 class ReflectionTest extends \PHPUnit_Framework_TestCase
 {
+    use HydratorTestTrait;
+
     /**
      * @var Reflection
      */

--- a/test/TestAsset/SimpleEntity.php
+++ b/test/TestAsset/SimpleEntity.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Hydrator\TestAsset;
+
+class SimpleEntity
+{
+    public $value;
+
+    /**
+     * @param  mixed $value
+     * @return void
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Exchange internal values from provided array
+     *
+     * @param  array $array
+     * @return void
+     */
+    public function exchangeArray(array $array)
+    {
+        if (array_key_exists('value', $array)) {
+            $this->setValue($array['value']);
+        }
+    }
+
+    /**
+     * Return an array representation of the object
+     *
+     * @return array
+     */
+    public function getArrayCopy()
+    {
+        return ['value' => $this->getValue()];
+    }
+}


### PR DESCRIPTION
Since `zendframework/zend-stdlib` is still requiring `zendframework/zend-hydrator` with `~1.1`, I would like to backport the naming strategy fix from #45.