### PR TITLE
Add return value to ExplodeStrategy::setValueDelimiter

### DIFF
--- a/src/Strategy/ExplodeStrategy.php
+++ b/src/Strategy/ExplodeStrategy.php
@@ -55,6 +55,8 @@ final class ExplodeStrategy implements StrategyInterface
         }
 
         $this->valueDelimiter = $delimiter;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
- fixes cs warning - docblock has @return self. 
- consistent with the other strategies.