### PR TITLE
Modified hydration of ArraySerializeable to take existing data into a…

### DIFF
--- a/src/ArraySerializable.php
+++ b/src/ArraySerializable.php
@@ -68,7 +68,7 @@ class ArraySerializable extends AbstractHydrator
         }
 
         if (is_callable([$object, 'exchangeArray'])) {
-            if(is_callable([$object, 'getArrayCopy'])) {
+            if (is_callable([$object, 'getArrayCopy'])) {
                 $original = $object->getArrayCopy($object);
                 $replacement = array_merge($original, $replacement);
             }

--- a/src/ArraySerializable.php
+++ b/src/ArraySerializable.php
@@ -70,7 +70,7 @@ class ArraySerializable extends AbstractHydrator
         if (is_callable([$object, 'exchangeArray'])) {
             if (is_callable([$object, 'getArrayCopy'])) {
                 $original = $object->getArrayCopy($object);
-                $replacement = array_merge($original, $replacement);
+                $replacement = \Zend\Stdlib\ArrayUtils::merge($original, $replacement);
             }
             $object->exchangeArray($replacement);
         } elseif (is_callable([$object, 'populate'])) {

--- a/src/ArraySerializable.php
+++ b/src/ArraySerializable.php
@@ -68,6 +68,10 @@ class ArraySerializable extends AbstractHydrator
         }
 
         if (is_callable([$object, 'exchangeArray'])) {
+            if(is_callable([$object, 'getArrayCopy'])) {
+                $original = $object->getArrayCopy($object);
+                $replacement = array_merge($original, $replacement);
+            }
             $object->exchangeArray($replacement);
         } elseif (is_callable([$object, 'populate'])) {
             $object->populate($replacement);

--- a/test/ArraySerializableTest.php
+++ b/test/ArraySerializableTest.php
@@ -119,7 +119,8 @@ class ArraySerializableTest extends TestCase
      * To preserve backwards compatibility, if getArrayCopy() is not implemented
      * by the to-be hydrated object, simply exchange the array
      */
-    public function testWillReplaceArrayIfNoGetArrayCopy() {
+    public function testWillReplaceArrayIfNoGetArrayCopy()
+    {
         $original = new ArraySerializableAssetNoGetArrayCopy();
 
         $data = [

--- a/test/ArraySerializableTest.php
+++ b/test/ArraySerializableTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\TestCase;
 use Zend\Hydrator\Exception\BadMethodCallException;
 use Zend\Hydrator\ArraySerializable;
 use ZendTest\Hydrator\TestAsset\ArraySerializable as ArraySerializableAsset;
-use ZendTest\Hydrator\TestAsset\ArraySerializableNoGetArrayCopy as ArraySerializableAssetNoGetArrayCopy;
 
 /**
  * Unit tests for {@see ArraySerializable}
@@ -121,10 +120,10 @@ class ArraySerializableTest extends TestCase
      */
     public function testWillReplaceArrayIfNoGetArrayCopy()
     {
-        $original = new ArraySerializableAssetNoGetArrayCopy();
+        $original = new \ZendTest\Hydrator\TestAsset\ArraySerializableNoGetArrayCopy();
 
         $data = [
-            'bar' => 'foo1'
+                'bar' => 'foo1'
         ];
 
         $expected = $data;

--- a/test/ArraySerializableTest.php
+++ b/test/ArraySerializableTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use Zend\Hydrator\Exception\BadMethodCallException;
 use Zend\Hydrator\ArraySerializable;
 use ZendTest\Hydrator\TestAsset\ArraySerializable as ArraySerializableAsset;
+use ZendTest\Hydrator\TestAsset\ArraySerializableNoGetArrayCopy as ArraySerializableAssetNoGetArrayCopy;
 
 /**
  * Unit tests for {@see ArraySerializable}
@@ -92,5 +93,42 @@ class ArraySerializableTest extends TestCase
         $object = $this->hydrator->hydrate($data, new ArraySerializableAsset());
 
         $this->assertSame($data, $object->getArrayCopy());
+    }
+
+    /**
+     * Verifies that when an object already has properties,
+     * these properties are preserved when it's hydrated with new data
+     * existing properties should get overwritten
+     */
+    public function testWillPreserveOriginalPropsAtHydration()
+    {
+        $original = new ArraySerializableAsset();
+
+        $data = [
+            'bar' => 'foo1'
+        ];
+
+        $expected = array_merge($original->getArrayCopy(), $data);
+
+        $actual = $this->hydrator->hydrate($data, $original);
+
+        $this->assertSame($expected, $actual->getArrayCopy());
+    }
+
+    /**
+     * To preserve backwards compatibility, if getArrayCopy() is not implemented
+     * by the to-be hydrated object, simply exchange the array
+     */
+    public function testWillReplaceArrayIfNoGetArrayCopy() {
+        $original = new ArraySerializableAssetNoGetArrayCopy();
+
+        $data = [
+            'bar' => 'foo1'
+        ];
+
+        $expected = $data;
+
+        $actual = $this->hydrator->hydrate($data, $original);
+        $this->assertSame($expected, $actual->getData());
     }
 }

--- a/test/TestAsset/ArraySerializableNoGetArrayCopy.php
+++ b/test/TestAsset/ArraySerializableNoGetArrayCopy.php
@@ -37,7 +37,8 @@ class ArraySerializableNoGetArrayCopy
     /**
      * Returns the internal data
      */
-    public function getData() {
+    public function getData()
+    {
         return $this->data;
     }
 }

--- a/test/TestAsset/ArraySerializableNoGetArrayCopy.php
+++ b/test/TestAsset/ArraySerializableNoGetArrayCopy.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Hydrator\TestAsset;
+
+class ArraySerializableNoGetArrayCopy
+{
+    protected $data = [];
+
+    public function __construct()
+    {
+        $this->data = [
+            "foo" => "bar",
+            "bar" => "foo",
+            "blubb" => "baz",
+            "quo" => "blubb"
+        ];
+    }
+
+    /**
+     * Exchange internal values from provided array
+     *
+     * @param  array $array
+     * @return void
+     */
+    public function exchangeArray(array $array)
+    {
+        $this->data = $array;
+    }
+
+    /**
+     * Returns the internal data
+     */
+    public function getData() {
+        return $this->data;
+    }
+}


### PR DESCRIPTION
@weierophinney As per our email exchange, I created a PR for this issue.

The hydration of `ArraySerializable` now takes into account existing values of the object being hydrated. 

This is done by calling `getArrayCopy()` to extract the array, then merge it with the data that we want to hydrate the array with, and finally calling `exchangeArray()`.

I originally was going to implement by calling `exchangeArray()` twice, once to return the existing  values (which is how `ArrayObject`'s `exchangeArray()` is implemented) but it didn't make sense since the hydrator would be making an assumption on return value.

So I decided to call `getArrayCopy()` if it exists, and just call `exchangeArray()` if it doesn't to preserve backwards compatibility (instead of throwing an exception).