### PR TITLE
Ensures that array values within an `ArraySerializable` are replaced

### DIFF
--- a/src/ArraySerializable.php
+++ b/src/ArraySerializable.php
@@ -9,8 +9,6 @@
 
 namespace Zend\Hydrator;
 
-use Zend\Stdlib\ArrayUtils;
-
 class ArraySerializable extends AbstractHydrator
 {
     /**
@@ -74,7 +72,7 @@ class ArraySerializable extends AbstractHydrator
             // remain following population.
             if (is_callable([$object, 'getArrayCopy'])) {
                 $original = $object->getArrayCopy($object);
-                $replacement = ArrayUtils::merge($original, $replacement);
+                $replacement = array_merge($original, $replacement);
             }
             $object->exchangeArray($replacement);
             return $object;


### PR DESCRIPTION
The fix introduced in #65 did a recursive merge of the data provided when hydrating an `ArraySerializable` object. However, array _values_ should not be merged, as changes to them are generally not patches, but rather replacements, as noted in #66.

This patch provides tests demonstrating the issues noted in #66, and modifies the `ArraySerializable` hydration logic to use `array_merge()` instead of `Zend\Stdlib\ArrayUtils::merge()`; all previous tests pass now, as do the newly added tests.

Fixes #66.