### PR TITLE
DateTimeFormatterStrategy passes special characters used by `date_create_from_format` to `date_format`

### DIFF
--- a/src/Strategy/DateTimeFormatterStrategy.php
+++ b/src/Strategy/DateTimeFormatterStrategy.php
@@ -49,7 +49,8 @@ final class DateTimeFormatterStrategy implements StrategyInterface
     public function extract($value)
     {
         if ($value instanceof DateTimeInterface) {
-            return $value->format($this->format);
+            $extractionFormat = preg_replace('/(?<![\\\\])[+|!\*]/', '', $this->format);
+            return $value->format($extractionFormat);
         }
 
         return $value;

--- a/src/Strategy/DateTimeFormatterStrategy.php
+++ b/src/Strategy/DateTimeFormatterStrategy.php
@@ -26,6 +26,11 @@ final class DateTimeFormatterStrategy implements StrategyInterface
     private $timezone;
 
     /**
+     * @var string
+     */
+    private $extractionFormat;
+
+    /**
      * Constructor
      *
      * @param string            $format
@@ -33,8 +38,9 @@ final class DateTimeFormatterStrategy implements StrategyInterface
      */
     public function __construct($format = DateTime::RFC3339, DateTimeZone $timezone = null)
     {
-        $this->format   = (string) $format;
+        $this->format = (string) $format;
         $this->timezone = $timezone;
+        $this->extractionFormat = preg_replace('/(?<![\\\\])[+|!\*]/', '', $this->format);
     }
 
     /**
@@ -49,8 +55,7 @@ final class DateTimeFormatterStrategy implements StrategyInterface
     public function extract($value)
     {
         if ($value instanceof DateTimeInterface) {
-            $extractionFormat = preg_replace('/(?<![\\\\])[+|!\*]/', '', $this->format);
-            return $value->format($extractionFormat);
+            return $value->format($this->extractionFormat);
         }
 
         return $value;

--- a/test/Strategy/DateTimeFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeFormatterStrategyTest.php
@@ -132,6 +132,14 @@ class DateTimeFormatterStrategyTest extends TestCase
         $this->assertEquals($expectedValue, $extracted);
     }
 
+    public function testCanExtractWithCreateFromFormatEscapedSpecialCharacters()
+    {
+        $date = DateTime::createFromFormat('Y-m-d', '2018-02-05');
+        $strategy = new DateTimeFormatterStrategy('Y-m-d\\+');
+        $extracted = $strategy->extract($date);
+        $this->assertEquals('2018-02-05+', $extracted);
+    }
+
     public function formatsWithSpecialCharactersProvider()
     {
         return [

--- a/test/Strategy/DateTimeFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeFormatterStrategyTest.php
@@ -22,6 +22,7 @@ use Zend\Hydrator\Strategy\DateTimeFormatterStrategy;
  */
 class DateTimeFormatterStrategyTest extends TestCase
 {
+
     public function testHydrate()
     {
         $strategy = new DateTimeFormatterStrategy('Y-m-d');
@@ -99,5 +100,53 @@ class DateTimeFormatterStrategyTest extends TestCase
 
         $strategy->extract($dateMock);
         $strategy->extract($dateImmutableMock);
+    }
+
+    /**
+     * @param string $format
+     * @param string $expectedValue
+     *
+     * @dataProvider formatsWithSpecialCharactersProvider
+     */
+    public function testAcceptsCreateFromFormatSpecialCharacters($format, $expectedValue)
+    {
+        $strategy = new DateTimeFormatterStrategy($format);
+        $hydrated = $strategy->hydrate($expectedValue);
+
+        $this->assertInstanceOf(DateTime::class, $hydrated);
+        $this->assertEquals($expectedValue, $hydrated->format('Y-m-d'));
+    }
+
+    /**
+     * @param string $format
+     * @param string $expectedValue
+     *
+     * @dataProvider formatsWithSpecialCharactersProvider
+     */
+    public function testCanExtractWithCreateFromFormatSpecialCharacters($format, $expectedValue)
+    {
+        $date = DateTime::createFromFormat($format, $expectedValue);
+        $strategy = new DateTimeFormatterStrategy($format);
+        $extracted = $strategy->extract($date);
+
+        $this->assertEquals($expectedValue, $extracted);
+    }
+
+    public function formatsWithSpecialCharactersProvider()
+    {
+        return [
+            [
+                '!Y-m-d',
+                '2018-02-05',
+            ],
+            [
+                'Y-m-d|',
+                '2018-02-05',
+            ],
+            [
+                'Y-m-d+',
+                '2018-02-05',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Hey guys,

I would like to use special chars for the date format, e.g. to ensure that if I pass a MySQL `date` string to the hydrator, an object with time reset to 0 is being returned.

Therefore, I had to strip un-escaped special chars (*, !, | and +) ([documentation](http://php.net/manual/en/datetime.createfromformat.php#refsect1-datetime.createfromformat-parameters)) from the format being passed to the `DateTimeInterface::format` method.