### PR TITLE
DateTimeFormatterStrategy could extract DateTimeImmutable aswell

### DIFF
--- a/src/Strategy/DateTimeFormatterStrategy.php
+++ b/src/Strategy/DateTimeFormatterStrategy.php
@@ -10,6 +10,7 @@
 namespace Zend\Hydrator\Strategy;
 
 use DateTime;
+use DateTimeInterface;
 use DateTimeZone;
 
 final class DateTimeFormatterStrategy implements StrategyInterface
@@ -47,7 +48,7 @@ final class DateTimeFormatterStrategy implements StrategyInterface
      */
     public function extract($value)
     {
-        if ($value instanceof DateTime) {
+        if ($value instanceof DateTimeInterface) {
             return $value->format($this->format);
         }
 

--- a/test/Strategy/DateTimeFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeFormatterStrategyTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Hydrator\Strategy;
 
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\Hydrator\Strategy\DateTimeFormatterStrategy;
@@ -86,7 +87,7 @@ class DateTimeFormatterStrategyTest extends TestCase
             ->with($format);
 
         $dateImmutableMock = $this
-            ->getMockBuilder(DateTime::class)
+            ->getMockBuilder(DateTimeImmutable::class)
             ->getMock();
 
         $dateImmutableMock

--- a/test/Strategy/DateTimeFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeFormatterStrategyTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Hydrator\Strategy;
 
+use DateTime;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\Hydrator\Strategy\DateTimeFormatterStrategy;
@@ -70,5 +71,32 @@ class DateTimeFormatterStrategyTest extends TestCase
 
         $this->assertEquals('26/04/2014', $strategy->extract(new \DateTime('2014-04-26')));
         $this->assertEquals('26/04/2015', $strategy->extract(new \DateTime('2015-04-26')));
+    }
+
+    public function testCanExtractAnyDateTimeInterface()
+    {
+        $dateMock = $this
+            ->getMockBuilder(DateTime::class)
+            ->getMock();
+
+        $format = 'Y-m-d';
+        $dateMock
+            ->expects($this->once())
+            ->method('format')
+            ->with($format);
+
+        $dateImmutableMock = $this
+            ->getMockBuilder(DateTime::class)
+            ->getMock();
+
+        $dateImmutableMock
+            ->expects($this->once())
+            ->method('format')
+            ->with($format);
+
+        $strategy = new DateTimeFormatterStrategy($format);
+
+        $strategy->extract($dateMock);
+        $strategy->extract($dateImmutableMock);
     }
 }


### PR DESCRIPTION
To ensure we can extract any `DateTimeInterface` related object (and therefore future objects), I changed the check to `DateTimeInterface` instead of `DateTime`.

Now we can also extract `DateTimeImmutable` objects.

Im not quite sure if we want to mix input and output of `StrategyInterface::extract` and `StrategyInterface::hydrate`.

Another way would be to provide a `DateTimeImmutableFormatterStrategy`.
I'm open for better ideas.