### PR TITLE
Allow primitive arrays and ArrayAccess objects as data sources

### DIFF
--- a/src/AbstractHydrator.php
+++ b/src/AbstractHydrator.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Hydrator;
 
+use ArrayAccess;
 use ArrayObject;
 
 abstract class AbstractHydrator implements
@@ -145,7 +146,7 @@ abstract class AbstractHydrator implements
      *
      * @param string $name The name of the strategy to use.
      * @param mixed $value The value that should be converted.
-     * @param array $data The whole data is optionally provided as context.
+     * @param array|ArrayAccess $data The whole data is optionally provided as context.
      * @return mixed
      */
     public function hydrateValue($name, $value, $data = null)
@@ -176,7 +177,7 @@ abstract class AbstractHydrator implements
      * Converts a value for hydration. If no naming strategy exists, the plain value is returned.
      *
      * @param string $name  The name to convert.
-     * @param array  $data  The whole data is optionally provided as context.
+     * @param array|ArrayAccess $data  The whole data is optionally provided as context.
      * @return mixed
      */
     public function hydrateName($name, $data = null)

--- a/src/Aggregate/AggregateHydrator.php
+++ b/src/Aggregate/AggregateHydrator.php
@@ -9,9 +9,11 @@
 
 namespace Zend\Hydrator\Aggregate;
 
+use ArrayAccess;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
+use Zend\Hydrator\Exception;
 use Zend\Hydrator\HydratorInterface;
 
 /**
@@ -53,8 +55,15 @@ class AggregateHydrator implements HydratorInterface, EventManagerAwareInterface
     /**
      * {@inheritDoc}
      */
-    public function hydrate(array $data, $object)
+    public function hydrate($data, $object)
     {
+        if (! is_array($data) && ! ($data instanceof ArrayAccess)) {
+            throw new Exception\BadMethodCallException(sprintf(
+                '`%s` expects the provided `$data` to be a primitive array or an object implementing `ArrayAccess`)',
+                __METHOD__
+            ));
+        }
+
         $event = new HydrateEvent($this, $object, $data);
 
         $this->getEventManager()->triggerEvent($event);

--- a/src/Aggregate/HydrateEvent.php
+++ b/src/Aggregate/HydrateEvent.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Hydrator\Aggregate;
 
+use ArrayAccess;
 use Zend\EventManager\Event;
 
 /**
@@ -30,16 +31,16 @@ class HydrateEvent extends Event
     protected $hydratedObject;
 
     /**
-     * @var array
+     * @var array|ArrayAccess
      */
     protected $hydrationData;
 
     /**
      * @param object $target
      * @param object $hydratedObject
-     * @param array  $hydrationData
+     * @param array|ArrayAccess $hydrationData
      */
-    public function __construct($target, $hydratedObject, array $hydrationData)
+    public function __construct($target, $hydratedObject, $hydrationData)
     {
         $this->target         = $target;
         $this->hydratedObject = $hydratedObject;
@@ -67,7 +68,7 @@ class HydrateEvent extends Event
     /**
      * Retrieves the data that is being used for hydration
      *
-     * @return array
+     * @return array|ArrayAccess
      */
     public function getHydrationData()
     {
@@ -75,9 +76,9 @@ class HydrateEvent extends Event
     }
 
     /**
-     * @param array $hydrationData
+     * @param array|ArrayAccess $hydrationData
      */
-    public function setHydrationData(array $hydrationData)
+    public function setHydrationData($hydrationData)
     {
         $this->hydrationData = $hydrationData;
     }

--- a/src/ArraySerializable.php
+++ b/src/ArraySerializable.php
@@ -9,6 +9,8 @@
 
 namespace Zend\Hydrator;
 
+use ArrayAccess;
+
 class ArraySerializable extends AbstractHydrator
 {
     /**
@@ -54,13 +56,20 @@ class ArraySerializable extends AbstractHydrator
      * Hydrates an object by passing $data to either its exchangeArray() or
      * populate() method.
      *
-     * @param  array $data
+     * @param  array|ArrayAccess $data
      * @param  object $object
      * @return object
      * @throws Exception\BadMethodCallException for an $object not implementing exchangeArray() or populate()
      */
-    public function hydrate(array $data, $object)
+    public function hydrate($data, $object)
     {
+        if (! is_array($data) && ! ($data instanceof ArrayAccess)) {
+            throw new Exception\BadMethodCallException(sprintf(
+                '`%s` expects the provided `$data` to be a primitive array or an object implementing `ArrayAccess`)',
+                __METHOD__
+            ));
+        }
+
         $replacement = [];
         foreach ($data as $key => $value) {
             $name = $this->hydrateName($key, $data);

--- a/src/ClassMethods.php
+++ b/src/ClassMethods.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Hydrator;
 
+use ArrayAccess;
 use Traversable;
 use Zend\Stdlib\ArrayUtils;
 
@@ -214,13 +215,20 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
      *
      * Hydrates an object by getter/setter methods of the object.
      *
-     * @param  array                            $data
+     * @param  array|ArrayAccess                $data
      * @param  object                           $object
      * @return object
      * @throws Exception\BadMethodCallException for a non-object $object
      */
-    public function hydrate(array $data, $object)
+    public function hydrate($data, $object)
     {
+        if (! is_array($data) && ! ($data instanceof ArrayAccess)) {
+            throw new Exception\BadMethodCallException(sprintf(
+                '`%s` expects the provided `$data` to be a primitive array or an object implementing `ArrayAccess`)',
+                __METHOD__
+            ));
+        }
+
         if (! is_object($object)) {
             throw new Exception\BadMethodCallException(sprintf(
                 '%s expects the provided $object to be a PHP object)',

--- a/src/DelegatingHydrator.php
+++ b/src/DelegatingHydrator.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Hydrator;
 
+use ArrayAccess;
 use Interop\Container\ContainerInterface;
 
 class DelegatingHydrator implements HydratorInterface
@@ -31,8 +32,15 @@ class DelegatingHydrator implements HydratorInterface
     /**
      * {@inheritdoc}
      */
-    public function hydrate(array $data, $object)
+    public function hydrate($data, $object)
     {
+        if (! is_array($data) && ! ($data instanceof ArrayAccess)) {
+            throw new Exception\BadMethodCallException(sprintf(
+                '`%s` expects the provided `$data` to be a primitive array or an object implementing `ArrayAccess`)',
+                __METHOD__
+            ));
+        }
+
         return $this->getHydrator($object)->hydrate($data, $object);
     }
 

--- a/src/HydrationInterface.php
+++ b/src/HydrationInterface.php
@@ -9,14 +9,16 @@
 
 namespace Zend\Hydrator;
 
+use ArrayAccess;
+
 interface HydrationInterface
 {
     /**
      * Hydrate $object with the provided $data.
      *
-     * @param  array $data
+     * @param  array|ArrayAccess $data
      * @param  object $object
      * @return object
      */
-    public function hydrate(array $data, $object);
+    public function hydrate($data, $object);
 }

--- a/src/ObjectProperty.php
+++ b/src/ObjectProperty.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Hydrator;
 
+use ArrayAccess;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -67,8 +68,15 @@ class ObjectProperty extends AbstractHydrator
      *
      * @throws Exception\BadMethodCallException for a non-object $object
      */
-    public function hydrate(array $data, $object)
+    public function hydrate($data, $object)
     {
+        if (! is_array($data) && ! ($data instanceof ArrayAccess)) {
+            throw new Exception\BadMethodCallException(sprintf(
+                '`%s` expects the provided `$data` to be a primitive array or an object implementing `ArrayAccess`)',
+                __METHOD__
+            ));
+        }
+
         if (! is_object($object)) {
             throw new Exception\BadMethodCallException(
                 sprintf('%s expects the provided $object to be a PHP object)', __METHOD__)

--- a/src/Reflection.php
+++ b/src/Reflection.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Hydrator;
 
+use ArrayAccess;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -45,12 +46,19 @@ class Reflection extends AbstractHydrator
     /**
      * Hydrate $object with the provided $data.
      *
-     * @param  array $data
+     * @param  array|ArrayAccess $data
      * @param  object $object
      * @return object
      */
-    public function hydrate(array $data, $object)
+    public function hydrate($data, $object)
     {
+        if (! is_array($data) && ! ($data instanceof ArrayAccess)) {
+            throw new Exception\BadMethodCallException(sprintf(
+                '`%s` expects the provided `$data` to be a primitive array or an object implementing `ArrayAccess`)',
+                __METHOD__
+            ));
+        }
+
         $reflProperties = self::getReflProperties($object);
         foreach ($data as $key => $value) {
             $name = $this->hydrateName($key, $data);


### PR DESCRIPTION
Our company is in the process of upgrading the now deprecated `mongo` extension to the new `mongodb` extension and the new extension no longer returns primitive arrays for documents.

It now returns [BSON](https://docs.mongodb.com/php-library/current/reference/bson/) objects which implement the `ArrayAccess` interface to access fields like primitive arrays.

We are using Zend Hydrator to then convert these objects to Apigility entities, but the `HydrationInterface::hydrate` method expects the data source to be a primitive array which obviously breaks our hydration completely unless we create array copies everywhere from these new BSON objects.

I personally don't see why the `hydrate` method needs to force primitive arrays when in reality it could access any iterable interface. I was tempted to use PHP 7.1 [`iterable`](http://php.net/manual/en/migration71.new-features.php#migration71.new-features.iterable-pseudo-type) pseudo-type instead, but that would be a bigger breaking change because it wouldn't support PHP 5.6 and PHP 7.0 and it would also require a bit more refactoring.

I also understand this is a big breaking change and that you might want to wait a while to get this in, so I'm not doing unit tests until this is an acceptable change. Let me know if this is something that you'd like to have in the future and I can prepare tests and documentation.