### PR TITLE
Added optional $dateTimeFallback to DateTimeFormatterStrategy

### DIFF
--- a/docs/book/strategy.md
+++ b/docs/book/strategy.md
@@ -104,6 +104,21 @@ This is a strategy that allows you to pass in options for:
 and DateTime instances. The input and output formats can be provided as
 constructor arguments.
 
+Constructor has third optional argument `$dateTimeFallback`.
+If enabled and createFromFormat method fails,
+given string is parsed by DateTime constructor.
+
+```php
+$strategy = new Zend\Hydrator\Strategy\DateTimeFormatterStrategy('Y-m-d H:i:s.uP');
+$hydrated1 = $strategy->hydrate('2016-03-04 10:29:40+01'); // value is not hydrated
+$hydrated2 = $strategy->hydrate('2016-03-04 10:29:40.123456+01'); // returns DateTime instance
+
+// both hydrated values are DateTime instances
+$strategy = new Zend\Hydrator\Strategy\DateTimeFormatterStrategy('Y-m-d H:i:s.uP', null, true);
+$hydrated1 = $strategy->hydrate('2016-03-04 10:29:40+01');
+$hydrated2 = $strategy->hydrate('2016-03-04 10:29:40.123456+01');
+```
+
 ### Zend\\Hydrator\\Strategy\\DefaultStrategy
 
 The `DefaultStrategy` simply proxies everything through, without performing any

--- a/src/Strategy/DateTimeFormatterStrategy.php
+++ b/src/Strategy/DateTimeFormatterStrategy.php
@@ -35,7 +35,7 @@ final class DateTimeFormatterStrategy implements StrategyInterface
      *
      * @param string            $format
      * @param DateTimeZone|null $timezone
-     * @param bool              $dateTimeFallback
+     * @param bool              $dateTimeFallback try to parse with DateTime when createFromFormat fails
      */
     public function __construct($format = DateTime::RFC3339, DateTimeZone $timezone = null, $dateTimeFallback = false)
     {

--- a/src/Strategy/DateTimeFormatterStrategy.php
+++ b/src/Strategy/DateTimeFormatterStrategy.php
@@ -26,15 +26,22 @@ final class DateTimeFormatterStrategy implements StrategyInterface
     private $timezone;
 
     /**
+     * @var bool
+     */
+    private $dateTimeFallback;
+
+    /**
      * Constructor
      *
      * @param string            $format
      * @param DateTimeZone|null $timezone
+     * @param bool              $dateTimeFallback
      */
-    public function __construct($format = DateTime::RFC3339, DateTimeZone $timezone = null)
+    public function __construct($format = DateTime::RFC3339, DateTimeZone $timezone = null, $dateTimeFallback = false)
     {
         $this->format   = (string) $format;
         $this->timezone = $timezone;
+        $this->dateTimeFallback = (bool) $dateTimeFallback;
     }
 
     /**
@@ -42,8 +49,7 @@ final class DateTimeFormatterStrategy implements StrategyInterface
      *
      * Converts to date time string
      *
-     * @param mixed|DateTime $value
-     *
+     * @param mixed|DateTimeInterface $value
      * @return mixed|string
      */
     public function extract($value)
@@ -61,8 +67,7 @@ final class DateTimeFormatterStrategy implements StrategyInterface
      * {@inheritDoc}
      *
      * @param mixed|string $value
-     *
-     * @return mixed|DateTime
+     * @return mixed|DateTimeInterface
      */
     public function hydrate($value)
     {
@@ -74,6 +79,10 @@ final class DateTimeFormatterStrategy implements StrategyInterface
             $hydrated = DateTime::createFromFormat($this->format, $value, $this->timezone);
         } else {
             $hydrated = DateTime::createFromFormat($this->format, $value);
+        }
+
+        if ($hydrated === false && $this->dateTimeFallback) {
+            $hydrated = new DateTime($value, $this->timezone);
         }
 
         return $hydrated ?: $value;

--- a/test/Strategy/DateTimeFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeFormatterStrategyTest.php
@@ -100,4 +100,17 @@ class DateTimeFormatterStrategyTest extends TestCase
         $strategy->extract($dateMock);
         $strategy->extract($dateImmutableMock);
     }
+
+    public function testCanHydrateWithDateTimeFallback()
+    {
+        $strategy = new DateTimeFormatterStrategy('Y-m-d', null, true);
+        $date = $strategy->hydrate('2018-09-06T12:10:30');
+
+        $this->assertSame('2018-09-06', $date->format('Y-m-d'));
+
+        $strategy = new DateTimeFormatterStrategy('Y-m-d', new \DateTimeZone('Europe/Prague'), true);
+        $date = $strategy->hydrate('2018-09-06T12:10:30');
+
+        $this->assertSame('Europe/Prague', $date->getTimezone()->getName());
+    }
 }


### PR DESCRIPTION
which converts `$value` to `DateTime` when `DateTime::createFromFormat` fails.

This is useful when hydrating dates which are in *various standardized formats* and can be handled by `new DateTime($dateString)`.

```php
$strategy = new Zend\Hydrator\Strategy\DateTimeFormatterStrategy('Y-m-d H:i:s.uP', null, true);
$hydrated1 = $strategy->hydrate( '2016-03-04 10:29:40+01'); // before PR this won't pass
$hydrated2 = $strategy->hydrate( '2016-03-04 10:29:40.123456+01');
```
