### PR TITLE
Move *EnabledInterface definitions to appropriate namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,14 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
+- [#83](https://github.com/zendframework/zend-hydrator/pull/83) renames `Zend\Hydrator\FilterEnabledInterface` to `Zend\Hydrator\Filter\FilterEnabledInterface` (new namespace).
+
+- [#83](https://github.com/zendframework/zend-hydrator/pull/83) renames `Zend\Hydrator\NamingStrategyEnabledInterface` to `Zend\Hydrator\NamingStrategy\NamingStrategyEnabledInterface` (new namespace).
+
+- [#83](https://github.com/zendframework/zend-hydrator/pull/83) renames `Zend\Hydrator\StrategyEnabledInterface` to `Zend\Hydrator\Strategy\StrategyEnabledInterface` (new namespace).
+
 - [#82](https://github.com/zendframework/zend-hydrator/pull/82) and [#85](https://github.com/zendframework/zend-hydrator/pull/85) change `Zend\Hydrator\NamingStrategy\MapNamingStrategy`
-- in the following ways:
+  in the following ways:
   - The class is now marked `final`.
   - The constructor is marked private. You can no longer instantiate it directly.
   - The class offers three new named constructors; one of these MUST be used to
@@ -67,6 +73,9 @@ All notable changes to this project will be documented in this file, in reverse 
 - Nothing.
 
 ### Removed
+
+- [#83](https://github.com/zendframework/zend-hydrator/pull/83) removes the constructor in `Zend\Hydrator\AbstractHydrator`. All
+  initialization is now either performed via property definitions or lazy-loading.
 
 - [#82](https://github.com/zendframework/zend-hydrator/pull/82) removes `Zend\Hydrator\NamingStrategy\ArrayMapNamingStrategy`. The functionality
   it provided has been merged into `Zend\Hydrator\NamingStrategy\MapNamingStrategy`;

--- a/docs/book/v3/migration.md
+++ b/docs/book/v3/migration.md
@@ -30,6 +30,14 @@ The minimum supported version of zend-serializer (used by the
 The minimum supported version of zend-servicemanager (used by the
 `HydratorPluginManager`) is now 3.3.2.
 
+## Renamed interfaces
+
+The following interfaces were renamed:
+
+- `Zend\Hydrator\FilterEnabledInterface` becomes `Zend\Hydrator\Filter\FilterEnabledInterface`.
+- `Zend\Hydrator\NamingStrategyEnabledInterface` becomes `Zend\Hydrator\NamingStrategy\NamingStrategyEnabledInterface`.
+- `Zend\Hydrator\StrategyEnabledInterface` becomes `Zend\Hydrator\Strategy\StrategyEnabledInterface`.
+
 ## Interface changes
 
 Each of the interfaces provided by this package have been updated to add
@@ -38,7 +46,7 @@ on parameters and return values. These include:
 
 - `Zend\Hydrator\ExtractionInterface`:
   - `extract($object)` becomes `extract(object $object) : array`
-- `Zend\Hydrator\FilterEnabledInterface`:
+- `Zend\Hydrator\Filter\FilterEnabledInterface` (was `Zend\Hydrator\FilterEnabledInterface`):
   - `addFilter($name, $filter, $condition = Zend\Hydrator\Filter\FilterComposite::CONDITION_OR)` becomes `addFilter(string $name, $filter, int $condition = Zend\Hydrator\Filter\FilterComposite::CONDITION_OR) : void`
   - `hasFilter($name)` becomes `hasFilter(string $name) : bool`
   - `removeFilter($name)` becomes `removeFilter(string $name) : void`
@@ -53,11 +61,11 @@ on parameters and return values. These include:
   - `setOptions($options)` becomes `setOptions(iterable $options) : void`
 - `Zend\Hydrator\HydratorProviderInterface`:
   - `getHydratorConfig()` becomes `getHydratorConfig() : array`
-- `Zend\Hydrator\NamingStrategyEnabledInterface`:
+- `Zend\Hydrator\NamingStrategy\NamingStrategyEnabledInterface` (was `Zend\Hydrator\NamingStrategyEnabledInterface`):
   - `setNamingStrategy(Zend\Hydrator\NamingStrategy\NamingStrategyInterface $strategy)` becomes `setNamingStrategy(Zend\Hydrator\NamingStrategy\NamingStrategyInterface $strategy) : void`
   - `getNamingStrategy()` becomes `getNamingStrategy() : Zend\Hydrator\NamingStrategy\NamingStrategyInterface`
   - `removeNamingStrategy()` becomes `removeNamingStrategy() : void`
-- `Zend\Hydrator\StrategyEnabledInterface`:
+- `Zend\Hydrator\Strategy\StrategyEnabledInterface` (was `Zend\Hydrator\StrategyEnabledInterface`):
   - `addStrategy($name, Zend\Hydrator\Strategy\StrategyInterface $strategy)` becomes `addStrategy(string $name, Zend\Hydrator\Strategy\StrategyInterface $strategy) : void`
   - `getStrategy($name)` becomes `getStrategy(string $name) : Zend\Hydrator\Strategy\StrategyInterface`
   - `hasStrategy($name)` becomes `hasStrategy(string $name) : bool`

--- a/docs/book/v3/naming-strategy/intro.md
+++ b/docs/book/v3/naming-strategy/intro.md
@@ -1,0 +1,85 @@
+# Naming Strategies
+
+Sometimes, the representation of a property should not share the same name as
+the property itself. As an example, when serializing an object for a JSON
+payload, you may want to convert camelCase properties to underscore_separated
+properties, and vice versa when deserializing JSON to an object.
+
+To make that possible, zend-hydrator provides _naming strategies_. These are
+similar to [strategies](../strategies.md), but instead of operating on the
+_value_, they operate on the _name_.
+
+## NamingStrategyInterface
+
+Naming strategies implement `Zend\Hydrator\NamingStrategy\NamingStrategyInterface`:
+
+```php
+namespace Zend\Hydrator\NamingStrategy;
+
+/**
+ * Allow property extraction / hydration for hydrator
+ */
+interface NamingStrategyInterface
+{
+    /**
+     * Converts the given name so that it can be extracted by the hydrator.
+     *
+     * @param null|mixed[] $data The original data for context.
+     */
+    public function hydrate(string $name, ?array $data = null) : string;
+
+    /**
+     * Converts the given name so that it can be hydrated by the hydrator.
+     *
+     * @param null|object $object The original object for context.
+     */
+    public function extract(string $name, ?object $object = null) : string;
+}
+```
+
+## Providing naming strategies
+
+Hydrators can indicate they will consume naming strategies, as well as allow
+registration of them, by implementing `Zend\Hydrator\NamingStrategy\NamingStrategyEnabledInterface`:
+
+```php
+namespace Zend\Hydrator\NamingStrategy;
+
+interface NamingStrategyEnabledInterface
+{
+    /**
+     * Sets the naming strategy.
+     */
+    public function setNamingStrategy(NamingStrategyInterface $strategy) : void;
+
+    /**
+     * Gets the naming strategy.
+     */
+    public function getNamingStrategy() : NamingStrategyInterface;
+
+    /**
+     * Checks if a naming strategy exists.
+     */
+    public function hasNamingStrategy() : bool;
+
+    /**
+     * Removes the naming strategy.
+     */
+    public function removeNamingStrategy() : void;
+}
+```
+
+We provide a default implementation of this interface within the
+`Zend\Hydrator\AbstractHydrator` definition. Its `getNamingStrategy()` will
+lazy-load an `IdentityNamingStrategy` if none has been previously registered.
+Since all shipped hydrators extend `AbstractHydrator`, they can consume naming
+strategies.
+
+## Shipped naming strategies
+
+We provide the following naming strategies:
+
+- [CompositeNamingStrategy](composite-naming-strategy.md)
+- [IdentityNamingStrategy](identity-naming-strategy.md)
+- [MapNamingStrategy](map-naming-strategy.md)
+- [UnderscoreNamingStrategy](underscore-naming-strategy.md)

--- a/docs/book/v3/strategy.md
+++ b/docs/book/v3/strategy.md
@@ -38,7 +38,7 @@ To allow strategies within your hydrator, `Zend\Hydrator\Strategy\StrategyEnable
 provides the following methods:
 
 ```php
-namespace Zend\Hydrator;
+namespace Zend\Hydrator\Strategy;
 
 use Zend\Hydrator\Strategy\StrategyInterface;
 

--- a/docs/book/v3/strategy.md
+++ b/docs/book/v3/strategy.md
@@ -1,87 +1,84 @@
 # Zend\\Hydrator\\Strategy
 
-You can add `Zend\Hydrator\Strategy\StrategyInterface` to any of the hydrators
-(except if it extends `Zend\Hydrator\AbstractHydrator` or implements
-`Zend\Hydrator\HydratorInterface` and `Zend\Hydrator\Strategy\StrategyEnabledInterface`)
-to manipulate the way how they behave on `extract()` and `hydrate()` for
-specific key / value pairs. This is the interface that needs to be implemented:
+You can compose `Zend\Hydrator\Strategy\StrategyInterface` instances in any of
+the hydrators to manipulate the way they behave on `extract()` and `hydrate()`
+for specific key/value pairs. The interface offers the following definitions:
 
 ```php
 namespace Zend\Hydrator\Strategy;
 
 interface StrategyInterface
 {
-     /**
-      * Converts the given value so that it can be extracted by the hydrator.
-      *
-      * @param mixed $value The original value.
-      * @return mixed Returns the value that should be extracted.
-      */
-     public function extract($value);
+    /**
+     * Converts the given value so that it can be extracted by the hydrator.
+     *
+     * @param  mixed       $value The original value.
+     * @param  null|object $object (optional) The original object for context.
+     * @return mixed       Returns the value that should be extracted.
+     */
+    public function extract($value, ?object $object = null);
 
-     /**
-      * Converts the given value so that it can be hydrated by the hydrator.
-      *
-      * @param mixed $value The original value.
-      * @return mixed Returns the value that should be hydrated.
-      */
-     public function hydrate($value);
+    /**
+     * Converts the given value so that it can be hydrated by the hydrator.
+     *
+     * @param  mixed      $value The original value.
+     * @param  null|array $data (optional) The original data for context.
+     * @return mixed      Returns the value that should be hydrated.
+     */
+    public function hydrate($value, ?array $data = null);
 }
 ```
 
-This interface is similar to `Zend\Hydrator\HydratorInterface`; the reason
-is that strategies provide a proxy implementation for `hydrate()` and `extract()`.
+This interface is similar to what the `Zend\Hydrator\ExtractionInterface` and
+`Zend\Hydrator\HydrationInterface` provide; the reason is that strategies
+provide a proxy implementation for `hydrate()` and `extract()` on individual
+values. For this reason, their return types are listed as mixed, versus as
+`array` and `object`, respectively.
 
 ## Adding strategies to the hydrators
 
-To allow strategies within your hydrator, `Zend\Hydrator\Strategy\StrategyEnabledInterface`
-provides the following methods:
+This package provides the interface `Zend\Hydrator\Strategy\StrategyEnabledInterface`.
+Hydrators can implement this interface, and then call on its `getStrategy()`
+method in order to extract or hydrate individual values. The interface has the
+following definition:
 
 ```php
 namespace Zend\Hydrator\Strategy;
-
-use Zend\Hydrator\Strategy\StrategyInterface;
 
 interface StrategyEnabledInterface
 {
     /**
      * Adds the given strategy under the given name.
-     *
-     * @param string $name The name of the strategy to register.
-     * @param StrategyInterface $strategy The strategy to register.
-     * @return HydratorInterface
      */
-    public function addStrategy($name, StrategyInterface $strategy);
+    public function addStrategy(string $name, StrategyInterface $strategy) : void;
 
     /**
      * Gets the strategy with the given name.
-     *
-     * @param string $name The name of the strategy to get.
-     * @return StrategyInterface
      */
-    public function getStrategy($name);
+    public function getStrategy(string $name) : StrategyInterface;
 
     /**
      * Checks if the strategy with the given name exists.
-     *
-     * @param string $name The name of the strategy to check for.
-     * @return bool
      */
-    public function hasStrategy($name);
+    public function hasStrategy(string $name) : bool;
 
     /**
      * Removes the strategy with the given name.
-     *
-     * @param string $name The name of the strategy to remove.
-     * @return HydratorInterface
      */
-    public function removeStrategy($name);
+    public function removeStrategy(string $name) : void;
 }
 ```
 
-Every hydrator shipped by default provides this functionality;
-`AbstractHydrator` fully implements it as well. As such, if you want to use this
-functionality in your own hydrators, you should extend `AbstractHydrator`.
+We provide a default implementation of the interface as part of
+`Zend\Hydrator\AbstractHydrator`; it uses an array property to store and
+retrieve strategies by name when extracting and hydrating values. Since all
+shipped hydrators are based on `AbstractHydrator`, they share these
+capabilities.
+
+Additionally, the functionality that consumes strategies within
+`AbstractHydrator` also contains checks if a naming strategy is composed, and,
+if present, will use it to translate the property name prior to looking up a
+  strategy for it.
 
 ## Available implementations
 
@@ -104,11 +101,11 @@ This is a strategy that allows you to pass in options for:
 and DateTime instances. The input and output formats can be provided as
 constructor arguments.
 
-As of version 2.4.1, this strategy now allows `DateTime` formats that use `!` to
-prepend the format, or `|` or `+` to append it; these ensure that, during
-hydration, the new `DateTime` instance created will set the time element
-accordingly. As a specific example, `Y-m-d|` will drop the time component,
-ensuring comparisons are based on a midnight time value.
+The strategy allows `DateTime` formats that use `!` to prepend the format, or
+`|` or `+` to append it; these ensure that, during hydration, the new `DateTime`
+instance created will set the time element accordingly. As a specific example,
+`Y-m-d|` will drop the time component, ensuring comparisons are based on a
+midnight time value.
 
 ### Zend\\Hydrator\\Strategy\\DefaultStrategy
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ pages:
       - "Strategies": v3/strategy.md
       - "Aggregates": v3/aggregate.md
       - "Naming Strategies":
+        - "Introduction": v3/naming-strategy/intro.md
         - "Identity": v3/naming-strategy/identity-naming-strategy.md
         - "Mapping": v3/naming-strategy/map-naming-strategy.md
         - "Underscore Mapping": v3/naming-strategy/underscore-naming-strategy.md

--- a/src/AbstractHydrator.php
+++ b/src/AbstractHydrator.php
@@ -36,17 +36,9 @@ abstract class AbstractHydrator implements
     /**
      * Composite to filter the methods, that need to be hydrated
      *
-     * @var Filter\FilterComposite
+     * @var null|Filter\FilterComposite
      */
     protected $filterComposite;
-
-    /**
-     * Initializes a new instance of this class.
-     */
-    public function __construct()
-    {
-        $this->filterComposite = new Filter\FilterComposite();
-    }
 
     /**
      * Gets the strategy with the given name.
@@ -181,7 +173,7 @@ abstract class AbstractHydrator implements
      */
     public function getFilter() : Filter\FilterInterface
     {
-        return $this->filterComposite;
+        return $this->getCompositeFilter();
     }
 
     /**
@@ -205,7 +197,7 @@ abstract class AbstractHydrator implements
      */
     public function addFilter(string $name, $filter, int $condition = Filter\FilterComposite::CONDITION_OR) : void
     {
-        $this->filterComposite->addFilter($name, $filter, $condition);
+        $this->getCompositeFilter()->addFilter($name, $filter, $condition);
     }
 
     /**
@@ -215,7 +207,7 @@ abstract class AbstractHydrator implements
      */
     public function hasFilter(string $name) : bool
     {
-        return $this->filterComposite->hasFilter($name);
+        return $this->getCompositeFilter()->hasFilter($name);
     }
 
     /**
@@ -229,7 +221,7 @@ abstract class AbstractHydrator implements
      */
     public function removeFilter(string $name) : void
     {
-        $this->filterComposite->removeFilter($name);
+        $this->getCompositeFilter()->removeFilter($name);
     }
 
     /**
@@ -272,5 +264,23 @@ abstract class AbstractHydrator implements
     public function removeNamingStrategy() : void
     {
         $this->namingStrategy = null;
+    }
+
+    /**
+     * Lazy-load the composite filter instance.
+     *
+     * If no instance is yet registerd for the $filterComposite property, this
+     * method will lazy load one.
+     *
+     * @throws Exception\DomainException if composed $filterComposite is not a
+     *     Filter\FilterComposite instance, nor null.
+     */
+    protected function getCompositeFilter() : Filter\FilterComposite
+    {
+        if (! $this->filterComposite) {
+            $this->filterComposite = new Filter\FilterComposite();
+        }
+
+        return $this->filterComposite;
     }
 }

--- a/src/AbstractHydrator.php
+++ b/src/AbstractHydrator.php
@@ -15,9 +15,9 @@ use function sprintf;
 
 abstract class AbstractHydrator implements
     HydratorInterface,
-    StrategyEnabledInterface,
-    FilterEnabledInterface,
-    NamingStrategyEnabledInterface
+    Strategy\StrategyEnabledInterface,
+    Filter\FilterEnabledInterface,
+    NamingStrategy\NamingStrategyEnabledInterface
 {
     /**
      * The list with strategies that this hydrator has.

--- a/src/AbstractHydrator.php
+++ b/src/AbstractHydrator.php
@@ -22,9 +22,9 @@ abstract class AbstractHydrator implements
     /**
      * The list with strategies that this hydrator has.
      *
-     * @var ArrayObject<Strategy\StrategyInterface>
+     * @var Strategy\StrategyInterface[]
      */
-    protected $strategies;
+    protected $strategies = [];
 
     /**
      * An instance of NamingStrategy\NamingStrategyInterface
@@ -45,7 +45,6 @@ abstract class AbstractHydrator implements
      */
     public function __construct()
     {
-        $this->strategies = new ArrayObject();
         $this->filterComposite = new Filter\FilterComposite();
     }
 
@@ -86,17 +85,17 @@ abstract class AbstractHydrator implements
      */
     public function hasStrategy(string $name) : bool
     {
-        if ($this->strategies->offsetExists($name)) {
+        if (isset($this->strategies[$name])) {
             return true;
         }
 
         if ($this->hasNamingStrategy()
-            && $this->strategies->offsetExists($this->getNamingStrategy()->hydrate($name))
+            && isset($this->strategies[$this->getNamingStrategy()->hydrate($name)])
         ) {
             return true;
         }
 
-        return $this->strategies->offsetExists('*');
+        return isset($this->strategies['*']);
     }
 
     /**

--- a/src/ClassMethods.php
+++ b/src/ClassMethods.php
@@ -65,17 +65,16 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
      */
     public function __construct(bool $underscoreSeparatedKeys = true, bool $methodExistsCheck = false)
     {
-        parent::__construct();
-
         $this->setUnderscoreSeparatedKeys($underscoreSeparatedKeys);
         $this->setMethodExistsCheck($methodExistsCheck);
 
         $this->callableMethodFilter = new Filter\OptionalParametersFilter();
 
-        $this->filterComposite->addFilter('is', new Filter\IsFilter());
-        $this->filterComposite->addFilter('has', new Filter\HasFilter());
-        $this->filterComposite->addFilter('get', new Filter\GetFilter());
-        $this->filterComposite->addFilter(
+        $compositeFilter = $this->getCompositeFilter();
+        $compositeFilter->addFilter('is', new Filter\IsFilter());
+        $compositeFilter->addFilter('has', new Filter\HasFilter());
+        $compositeFilter->addFilter('get', new Filter\GetFilter());
+        $compositeFilter->addFilter(
             'parameter',
             new Filter\OptionalParametersFilter(),
             Filter\FilterComposite::CONDITION_AND
@@ -149,7 +148,7 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
         // pass 1 - finding out which properties can be extracted, with which methods (populate hydration cache)
         if (! isset($this->extractionMethodsCache[$objectClass])) {
             $this->extractionMethodsCache[$objectClass] = [];
-            $filter                                     = $this->filterComposite;
+            $filter                                     = $this->getCompositeFilter();
             $methods                                    = get_class_methods($object);
 
             if ($object instanceof Filter\FilterProviderInterface) {

--- a/src/Filter/FilterEnabledInterface.php
+++ b/src/Filter/FilterEnabledInterface.php
@@ -7,9 +7,9 @@
 
 declare(strict_types=1);
 
-namespace Zend\Hydrator;
+namespace Zend\Hydrator\Filter;
 
-interface FilterEnabledInterface extends Filter\FilterProviderInterface
+interface FilterEnabledInterface extends FilterProviderInterface
 {
     /**
      * Add a new filter to take care of what needs to be hydrated.
@@ -30,9 +30,9 @@ interface FilterEnabledInterface extends Filter\FilterProviderInterface
      * </code>
      *
      * @param string $name Index in the composite
-     * @param callable|Filter\FilterInterface $filter
+     * @param callable|FilterInterface $filter
      */
-    public function addFilter(string $name, $filter, int $condition = Filter\FilterComposite::CONDITION_OR) : void;
+    public function addFilter(string $name, $filter, int $condition = FilterComposite::CONDITION_OR) : void;
 
     /**
      * Check whether a specific filter exists at key $name or not

--- a/src/NamingStrategy/NamingStrategyEnabledInterface.php
+++ b/src/NamingStrategy/NamingStrategyEnabledInterface.php
@@ -7,21 +7,19 @@
 
 declare(strict_types=1);
 
-namespace Zend\Hydrator;
+namespace Zend\Hydrator\NamingStrategy;
 
 interface NamingStrategyEnabledInterface
 {
     /**
      * Adds the given naming strategy
-     *
-     * @param NamingStrategy\NamingStrategyInterface $strategy The naming to register.
      */
-    public function setNamingStrategy(NamingStrategy\NamingStrategyInterface $strategy) : void;
+    public function setNamingStrategy(NamingStrategyInterface $strategy) : void;
 
     /**
      * Gets the naming strategy.
      */
-    public function getNamingStrategy() : NamingStrategy\NamingStrategyInterface;
+    public function getNamingStrategy() : NamingStrategyInterface;
 
     /**
      * Checks if a naming strategy exists.

--- a/src/Reflection.php
+++ b/src/Reflection.php
@@ -33,7 +33,7 @@ class Reflection extends AbstractHydrator
         $result = [];
         foreach (self::getReflProperties($object) as $property) {
             $propertyName = $this->extractName($property->getName(), $object);
-            if (! $this->filterComposite->filter($propertyName)) {
+            if (! $this->getCompositeFilter()->filter($propertyName)) {
                 continue;
             }
 

--- a/src/Strategy/StrategyEnabledInterface.php
+++ b/src/Strategy/StrategyEnabledInterface.php
@@ -7,19 +7,19 @@
 
 declare(strict_types=1);
 
-namespace Zend\Hydrator;
+namespace Zend\Hydrator\Strategy;
 
 interface StrategyEnabledInterface
 {
     /**
      * Adds the given strategy under the given name.
      */
-    public function addStrategy(string $name, Strategy\StrategyInterface $strategy) : void;
+    public function addStrategy(string $name, StrategyInterface $strategy) : void;
 
     /**
      * Gets the strategy with the given name.
      */
-    public function getStrategy(string $name) : Strategy\StrategyInterface;
+    public function getStrategy(string $name) : StrategyInterface;
 
     /**
      * Checks if the strategy with the given name exists.


### PR DESCRIPTION
This patch does the following:

- It moves each `*EnabledInterface` to the proper subnamespace (for some reason, these were created in the top-level namespace, and should not be).
- It updates `AbstractHydrator` such that it no longer needs a constructor:
  - `$strategies` is now defined initially as an empty array.
  - `$filterComposite` gets lazy-loaded by a new method, `getCompositeFilter()`; all references to `$filterComposite` were updated to use this new method in order to guarantee a `FilterComposite` instance is used.

Functionality remains the same, and all tests continue to pass.

I have also updated documentation and added migration notes.