### PR TITLE
Do not allow direct instantiation of a MapNamingStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,19 +17,20 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- [#82](https://github.com/zendframework/zend-hydrator/pull/82) changes `Zend\Hydrator\NamingStrategy\MapNamingStrategy` in the following ways:
-  - The constructor is removed. If you instantiate an instance using
-    `new MapNamingStrategy(...)`, the strategy will act as a no-op.
+- [#82](https://github.com/zendframework/zend-hydrator/pull/82) and [#85](https://github.com/zendframework/zend-hydrator/pull/85) change `Zend\Hydrator\NamingStrategy\MapNamingStrategy`
+- in the following ways:
   - The class is now marked `final`.
-  - The class offers three new named constructors:
-  - `MapNamingStrategy::createFromExtractionMap(array $extractionMap) : MapNamingStrategy`
-    will use the provided extraction map for extraction operations, and flip it
-    for hydration operations.
-  - `MapNamingStrategy::createFromHydrationMap(array $hydrationMap) : MapNamingStrategy`
-    will use the provided hydration map for hydration operations, and flip it
-    for extraction operations.
-  - `MapNamingStrategy::createFromAssymetricMap(array $extractionMap, array $hydrationMap) : MapNamingStrategy`
-    will use the appropriate map based on the requested operation.
+  - The constructor is marked private. You can no longer instantiate it directly.
+  - The class offers three new named constructors; one of these MUST be used to
+    create an instance, as the constructor is now final:
+    - `MapNamingStrategy::createFromExtractionMap(array $extractionMap) : MapNamingStrategy`
+      will use the provided extraction map for extraction operations, and flip it
+      for hydration operations.
+    - `MapNamingStrategy::createFromHydrationMap(array $hydrationMap) : MapNamingStrategy`
+      will use the provided hydration map for hydration operations, and flip it
+      for extraction operations.
+    - `MapNamingStrategy::createFromAssymetricMap(array $extractionMap, array $hydrationMap) : MapNamingStrategy`
+      will use the appropriate map based on the requested operation.
 
 - [#80](https://github.com/zendframework/zend-hydrator/pull/80) bumps the minimum supported PHP version to 7.2.
 

--- a/docs/book/v3/migration.md
+++ b/docs/book/v3/migration.md
@@ -190,8 +190,8 @@ In the first two cases, the constructor will flip the arrays for purposes of the
 opposite interaction; e.g., using `createFromExtractionMap()` will create a
 hydration map based on an `array_flip()` of the extraction map provided.
 
-If you instantiate the naming strategy without these methods, it will act as a
-no-op for purposes of both extraction and hydration.
+**You MUST use one of these methods to create an instance,** as the constructor
+is now marked `private`.
 
 ## HydratorPluginManager
 

--- a/src/NamingStrategy/MapNamingStrategy.php
+++ b/src/NamingStrategy/MapNamingStrategy.php
@@ -78,6 +78,19 @@ final class MapNamingStrategy implements NamingStrategyInterface
     }
 
     /**
+     * Do not allow direct instantiation of this class.
+     *
+     * Users should use one of the named constructors:
+     *
+     * - createFromExtractionMap()
+     * - createFromHydrationMap()
+     * - createFromAssymetricMap()
+     */
+    private function __construct()
+    {
+    }
+
+    /**
      * Safely flip mapping array.
      *
      * @param  string[] $array Array to flip

--- a/test/NamingStrategy/MapNamingStrategyTest.php
+++ b/test/NamingStrategy/MapNamingStrategyTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace ZendTest\Hydrator\NamingStrategy;
 
+use Error;
 use PHPUnit\Framework\TestCase;
 use Zend\Hydrator\Exception;
 use Zend\Hydrator\NamingStrategy\MapNamingStrategy;
@@ -88,15 +89,15 @@ class MapNamingStrategyTest extends TestCase
         MapNamingStrategy::createFromHydrationMap([$invalidKey => 'foo']);
     }
 
-    public function testExtractReturnsVerbatimWhenNoExtractionMapProvided()
+    public function testExtractReturnsVerbatimWhenEmptyExtractionMapProvided()
     {
-        $strategy = new MapNamingStrategy();
+        $strategy = MapNamingStrategy::createFromExtractionMap([]);
         $this->assertEquals('some_stuff', $strategy->extract('some_stuff'));
     }
 
-    public function testHydrateReturnsVerbatimWhenNoHydrationMapProvided()
+    public function testHydrateReturnsVerbatimWhenEmptyHydrationMapProvided()
     {
-        $strategy = new MapNamingStrategy([]);
+        $strategy = MapNamingStrategy::createFromHydrationMap([]);
         $this->assertEquals('some_stuff', $strategy->hydrate('some_stuff'));
     }
 


### PR DESCRIPTION
Per #85, we should not allow direct instantiation of a `MapNamingStrategy`, as users porting from v2 to v3 code should learn immediately that they need to switch to one of the named constructors.

Fixes #85.