### PR TITLE
Provide a standalone plugin manager implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#87](https://github.com/zendframework/zend-hydrator/pull/87) adds `Zend\Hydrator\HydratorPluginManagerInterface` to allow
+  type-hinting on plugin manager implementations. The interface simply extends
+  the [PSR-11 ContainerInterface](https://www.php-fig.org/psr/psr-11/).
+
+- [#87](https://github.com/zendframework/zend-hydrator/pull/87) adds `Zend\Hydrator\StandaloneHydratorPluginManager` as an implementation
+  of each of `Psr\Container\ContainerInterface` and `Zend\Hydrator\HydratorPluginManagerInterface`,
+  along with a factory for creating it, `Zend\Hydrator\StandaloneHydratorPluginManagerFactory`.
+  It can act as a replacement for `Zend\Hydrator\HydratorPluginManager`, but
+  only supports the shipped hydrator implementations. See the [plugin manager documentation](https://docs.zendframework.com/zend-hydrator/v3/plugin-managers/)
+  for more details on usage.
+
 - [#79](https://github.com/zendframework/zend-hydrator/pull/79) adds a third, optional parameter to the `DateTimeFormatterStrategy` constructor.
   The parameter is a boolean, and, when enabled, a string that can be parsed by
   the `DateTime` constructor will still result in a `DateTime` instance during
@@ -27,6 +38,15 @@ All notable changes to this project will be documented in this file, in reverse 
 
   Aliases resolving the original class name to the new class were also added to
   the `HydratorPluginManager` to ensure you can still obtain instances.
+
+- [#87](https://github.com/zendframework/zend-hydrator/pull/87) modifies `Zend\Hydrator\ConfigProvider` to add a factory entry for
+  `Zend\Hydrator\StandaloneHydratorPluginManager`.
+
+- [#87](https://github.com/zendframework/zend-hydrator/pull/87) modifies `Zend\Hydrator\ConfigProvider` to change the target of the
+  `HydratorManager` alias based on the presence of the zend-servicemanager
+  package; if the package is not available, the target points to
+  `Zend\Hydrator\StandaloneHydratorPluginManager` instead of
+  `Zend\Hydrator\HydratorPluginManager`.
 
 - [#83](https://github.com/zendframework/zend-hydrator/pull/83) renames `Zend\Hydrator\FilterEnabledInterface` to `Zend\Hydrator\Filter\FilterEnabledInterface` (new namespace).
 

--- a/docs/book/v3/migration.md
+++ b/docs/book/v3/migration.md
@@ -222,4 +222,11 @@ is now marked `private`.
 This version removes support for zend-servicemanager v2 service names. Under
 zend-servicemanager v2, most special characters were removed, and the name
 normalized to all lowercase. Now, only fully qualified class names are mapped to
-factories, and short names (names omitting the namespace) are mapped as aliases.
+factories, and short names (names omitting the namespace and/or "Hydrator"
+suffix) are mapped as aliases.
+
+Additionally, version 3 ships a standalone, PSR-11 compliant version,
+`Zend\Hydrator\StandaloneHydratorPluginManager`. By default, the `HydratorManager`
+service alias will point to the `StandaloneHydratorPluginManager` if
+zend-servicemanager is not installed, and the `HydratorPluginManager` otherwise.
+See the [plugin managers chapter](plugin-managers.md) for more details.

--- a/docs/book/v3/plugin-managers.md
+++ b/docs/book/v3/plugin-managers.md
@@ -1,0 +1,197 @@
+# Plugin Managers
+
+It can be useful to compose a plugin manager from which you can retrieve
+hydrators; in fact, `Zend\Hydrator\DelegatingHydrator` does exactly that!
+With such a manager, you can retrieve instances using short names, or instances
+that have dependencies on other services, without needing to know the details of
+how that works.
+
+Examples of Hydrator plugin managers in real-world scenarios include:
+
+- [hydrating database result sets](https://docs.zendframework.com/zend-db/result-set/#zend92db92resultset92hydratingresultset)
+- [preparing API payloads](https://docs.zendframework.com/zend-expressive-hal/resource-generator/#resourcegenerator)
+
+## HydratorPluginManagerInterface
+
+We provide two plugin manager implementations. Essentially, they only need to
+implement the [PSR-11 ContainerInterface](https://www.php-fig.org/psr/psr-11/),
+but plugin managers in current versions of [zend-servicemanager](https://docs.zendframework.com/zend-servicemanager/)
+only implement it indirectly via the container-interop project.
+
+As such, we ship `Zend\Hydrator\HydratorPluginManagerInterface`, which simply
+extends the PSR-11 `Psr\Container\ContainerInterface`. Each of our
+implementations implement it.
+
+## HydratorPluginManager
+
+If you have used zend-hydrator prior to version 3, you are likely already
+familiar with this class, as it has been the implementation we have shipped from
+initial versions. The `HydratorPluginManager` extends the zend-servicemanager
+`AbstractPluginManager`, and has the following behaviors:
+
+- It will only return `Zend\Hydrator\HydratorInterface` instances.
+- It defines short-name aliases for all shipped hydrators (the class name minus
+  the namespace), in a variety of casing combinations.
+- All but the `DelegatingHydrator` are defined as invokable services (meaning
+  they can be instantiated without any constructor arguments).
+- The `DelegatingHydrator` is configured as a factory-based service, mapping to
+  the `Zend\Hydrator\DelegatingHydratorFactory`.
+- No services are shared; a new instance is created each time you call `get()`.
+
+### HydratorPluginManagerFactory
+
+`Zend\Hydrator\HydratorPluginManager` is mapped to the factory
+`Zend\Hydrator\HydratorPluginManagerFactory` when wired to the dependency
+injection container.
+
+The factory will look for the `config` service, and use the `hydrators`
+configuration key to seed it with additional services. This configuration key
+should map to an array that follows [standard zend-servicemanager configuration](https://docs.zendframework.com/zend-servicemanager/configuring-the-service-manager/).
+
+## StandaloneHydratorPluginManager
+
+`Zend\Hydrator\StandaloneHydratorPluginManager` provides an implementation that
+has no dependencies on other libraries. **It can only load the hydrators shipped
+with zend-hydrator**.
+
+### StandardHydratorPluginManagerFactory
+
+`Zend\Hydrator\StandardHydratorPluginManager` is mapped to the factory
+`Zend\Hydrator\StandardHydratorPluginManagerFactory` when wired to the dependency
+injection container.
+
+## HydratorManager alias
+
+`Zend\Hydrator\ConfigManager` defines an alias service, `HydratorManager`. That
+service will point to `Zend\Hydrator\HydratorPluginManager` if
+zend-servicemanager is installed, and `Zend\Hydrator\StandaloneHydratorPluginManager`
+otherwise.
+
+## Custom plugin managers
+
+If you do not want to use zend-servicemanager, but want a plugin manager that is
+customizable, or at least capable of loading the hydrators you have defined for
+your application, you should write a custom implementation of
+`Zend\Hydrator\HydratorPluginManagerInterface`, and wire it to the
+`HydratorManager` service, and/or one of the existing service names.
+
+As an example, if you want a configurable solution that uses factories, and want
+those factories capable of pulling application-level dependencies, you might do
+something like the following:
+
+```php
+namespace YourApplication;
+
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+use Zend\Hydrator\HydratorInterface;
+use Zend\Hydrator\HydratorPluginManagerInterface;
+use Zend\Hydrator\StandaloneHydratorPluginManager;
+
+class CustomHydratorPluginManager implements
+    ContainerInterface,
+    HydratorPluginManagerInterface
+{
+    /** @var ContainerInterface */
+    private $appContainer;
+
+    /** @var StandaloneHydratorPluginManager */
+    private $defaults;
+
+    /** @var array<string, string|callable> */
+    private $factories = [];
+
+    public function __construct(ContainerInterface $appContainer)
+    {
+        $this->appContainer = $appContainer;
+        $this->defaults = new StandaloneHydratorPluginManager();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get($id) : HydratorInterface
+    {
+        if (! isset($this->factories[$id]) && ! $this->defaults->has($id)) {
+            $message = sprintf('Hydrator service %s not found', $id);
+            throw new class($message) extends RuntimeException implements NotFoundExceptionInterface {};
+        }
+
+        // Default was requested; fallback to standalone container
+        if (! isset($this->factories[$id])) {
+            return $this->defaults->get($id);
+        }
+
+        $factory = $this->factories[$id];
+        if (is_string($factory)) {
+            $this->factories[$id] = $factory = new $factory();
+        }
+
+        return $factory($this->appContainer, $id);
+    }
+
+    public function has($id) : bool
+    {
+        return isset($this->factories[$id]) || $this->defaults->has($id);
+    }
+
+    public function setFactoryClass(string $name, string $factory) : void
+    {
+        $this->factories[$name] = $factory;
+    }
+
+    public function setFactory(string $name, callable $factory) : void
+    {
+        $this->factories[$name] = $factory;
+    }
+}
+
+class CustomHydratorPluginManagerFactory
+{
+    public function __invoke(ContainerInterface $container) : CustomHydratorPluginManager
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = $config['hydrators']['factories'] ?? [];
+
+        $manager = new CustomHydratorPluginManager($this);
+
+        if ([] !== $config) {
+            $this->configureManager($manager, $config);
+        }
+
+        return $manager;
+    }
+
+    /**
+     * @param array<string, string|callable> $config
+     */
+    private function configureManager(CustomHydratorPluginManager $manager, array $config) : void
+    {
+        foreach ($config as $name => $factory) {
+            is_string($factory)
+                ? $manager->setFactoryClass($name, $factory)
+                : $manager->setFactory($name, $factory);
+        }
+    }
+}
+
+// in config/autoload/hydrators.global.php or similar:
+return [
+    'dependencies' => [
+        'aliases' => [
+            'HydratorManager' => \YourApplication\CustomHydratorPluginManager::class,
+        ],
+        'factories' => [
+            \YourApplication\CustomHydratorPluginManager::class => \YourApplication\CustomHydratorPluginManagerFactory::class
+        ],
+    ],
+    'hydrators' => [
+        'factories' => [
+            \Blog\PostHydrator::class => \Blog\PostHydratorFactory::class,
+            \News\ItemHydrator::class => \News\ItemHydratorFactory::class,
+            // etc.
+        ],
+    ],
+];
+```

--- a/docs/book/v3/plugin-managers.md
+++ b/docs/book/v3/plugin-managers.md
@@ -80,6 +80,8 @@ those factories capable of pulling application-level dependencies, you might do
 something like the following:
 
 ```php
+// In src/YourApplication/CustomHydratorPluginManager.php:
+
 namespace YourApplication;
 
 use Psr\Container\NotFoundExceptionInterface;
@@ -89,9 +91,7 @@ use Zend\Hydrator\HydratorInterface;
 use Zend\Hydrator\HydratorPluginManagerInterface;
 use Zend\Hydrator\StandaloneHydratorPluginManager;
 
-class CustomHydratorPluginManager implements
-    ContainerInterface,
-    HydratorPluginManagerInterface
+class CustomHydratorPluginManager implements HydratorPluginManagerInterface
 {
     /** @var ContainerInterface */
     private $appContainer;
@@ -146,6 +146,14 @@ class CustomHydratorPluginManager implements
         $this->factories[$name] = $factory;
     }
 }
+```
+
+```php
+// In src/YourApplication/CustomHydratorPluginManagerFactory.php:
+
+namespace YourApplication;
+
+use Psr\Container\ContainerInterface;
 
 class CustomHydratorPluginManagerFactory
 {
@@ -175,8 +183,11 @@ class CustomHydratorPluginManagerFactory
         }
     }
 }
+```
 
+```php
 // in config/autoload/hydrators.global.php or similar:
+
 return [
     'dependencies' => [
         'aliases' => [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ pages:
         - "Mapping": v3/naming-strategy/map-naming-strategy.md
         - "Underscore Mapping": v3/naming-strategy/underscore-naming-strategy.md
         - "Composite": v3/naming-strategy/composite-naming-strategy.md
+      - "Plugin Managers": v3/plugin-managers.md
       - Migration: v3/migration.md
     - v2:
         - "Quick Start": v2/quick-start.md

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Zend\Hydrator;
 
+use Zend\ServiceManager\ServiceManager;
+
 class ConfigProvider
 {
     /**
@@ -26,16 +28,25 @@ class ConfigProvider
     /**
      * Return dependency mappings for this component.
      *
+     * If zend-servicemanager is installed, this will alias the HydratorPluginManager
+     * to the `HydratorManager` service; otherwise, it aliases the
+     * StandaloneHydratorPluginManager.
+     *
      * @return string[][]
      */
     public function getDependencyConfig() : array
     {
+        $hydratorManagerTarget = class_exists(ServiceManager::class)
+            ? HydratorPluginManager::class
+            : StandaloneHydratorPluginManager::class;
+
         return [
             'aliases' => [
-                'HydratorManager' => HydratorPluginManager::class,
+                'HydratorManager' => $hydratorManagerTarget,
             ],
             'factories' => [
-                HydratorPluginManager::class => HydratorPluginManagerFactory::class,
+                HydratorPluginManager::class           => HydratorPluginManagerFactory::class,
+                StandaloneHydratorPluginManager::class => StandaloneHydratorPluginManagerFactory::class,
             ],
         ];
     }

--- a/src/DelegatingHydratorFactory.php
+++ b/src/DelegatingHydratorFactory.php
@@ -25,10 +25,10 @@ class DelegatingHydratorFactory
     /**
      * Locate and return a HydratorPluginManager instance.
      */
-    private function marshalHydratorPluginManager(ContainerInterface $container) : HydratorPluginManager
+    private function marshalHydratorPluginManager(ContainerInterface $container) : ContainerInterface
     {
         // Already one? Return it.
-        if ($container instanceof HydratorPluginManager) {
+        if ($container instanceof HydratorPluginManagerInterface) {
             return $container;
         }
 

--- a/src/Exception/MissingHydratorServiceException.php
+++ b/src/Exception/MissingHydratorServiceException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-hydrator for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-hydrator/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Hydrator\Exception;
+
+use Psr\Container\NotFoundExceptionInterface;
+
+use function sprintf;
+
+class MissingHydratorServiceException extends InvalidArgumentException implements NotFoundExceptionInterface
+{
+    public static function forService(string $serviceName) : self
+    {
+        return new self(sprintf(
+            'Unable to resolve "%s" to a hydrator service.',
+            $serviceName
+        ));
+    }
+}

--- a/src/HydratorPluginManager.php
+++ b/src/HydratorPluginManager.php
@@ -23,7 +23,7 @@ use function sprintf;
  *
  * Enforces that adapters retrieved are instances of HydratorInterface
  */
-class HydratorPluginManager extends AbstractPluginManager
+class HydratorPluginManager extends AbstractPluginManager implements HydratorPluginManagerInterface
 {
     /**
      * Default aliases

--- a/src/HydratorPluginManagerFactory.php
+++ b/src/HydratorPluginManagerFactory.php
@@ -12,7 +12,9 @@ namespace Zend\Hydrator;
 use Psr\Container\ContainerInterface;
 use Zend\ServiceManager\Config;
 
+use function class_exists;
 use function is_array;
+use function sprintf;
 
 class HydratorPluginManagerFactory
 {
@@ -25,9 +27,22 @@ class HydratorPluginManagerFactory
      * configuration.
      *
      * @see https://docs.zendframework.com/zend-expressive/v3/features/container/config/
+     * @throws Exception\DomainException if zend-servicemanager is not installed.
      */
     public function __invoke(ContainerInterface $container, string $name, ?array $options = []) : HydratorPluginManager
     {
+        if (! class_exists(Config::class)) {
+            throw new Exception\DomainException(sprintf(
+                '%s requires the zendframework/zend-servicemanager package, which is not installed.'
+                . ' If you do not want to install that package, you can use the %s instead;'
+                . ' however, that version does not have support for the "hydrators"'
+                . ' configuration outside of aliases, invokables, and factories. If you'
+                . ' need those features, please install zendframework/zend-servicemanager.',
+                HydratorPluginManager::class,
+                StandaloneHydratorPluginManager::class
+            ));
+        }
+
         $pluginManager = new HydratorPluginManager($container, $options ?: []);
 
         // If this is in a zend-mvc application, the ServiceListener will inject

--- a/src/HydratorPluginManagerInterface.php
+++ b/src/HydratorPluginManagerInterface.php
@@ -11,6 +11,9 @@ namespace Zend\Hydrator;
 
 use Psr\Container\ContainerInterface;
 
+/**
+ * @method HydratorInterface get(string $id)
+ */
 interface HydratorPluginManagerInterface extends ContainerInterface
 {
 }

--- a/src/HydratorPluginManagerInterface.php
+++ b/src/HydratorPluginManagerInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-hydrator for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-hydrator/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Hydrator;
+
+use Psr\Container\ContainerInterface;
+
+interface HydratorPluginManagerInterface extends ContainerInterface
+{
+}

--- a/src/StandaloneHydratorPluginManager.php
+++ b/src/StandaloneHydratorPluginManager.php
@@ -34,9 +34,7 @@ use function strtolower;
  * wire hydrators into your application container; or write your own
  * implementation.
  */
-final class StandaloneHydratorPluginManager implements
-    ContainerInterface,
-    HydratorPluginManagerInterface
+final class StandaloneHydratorPluginManager implements HydratorPluginManagerInterface
 {
     /**
      * To allow using the short name (class name without namespace), this maps
@@ -107,15 +105,6 @@ final class StandaloneHydratorPluginManager implements
 
     /**
      * Resolve a service name from an identifier.
-     *
-     * If $name is registered in $factories, the method returns it verbatim.
-     *
-     * Next it checks if the $name is registered verbatim in $aliases; if so,
-     * it returns the target of the alias.
-     *
-     * finally, it does a strtolower() on it and looks to see if it exists
-     * in the $aliases array; if so, it returns the target of the alias,
-     * otherwise it returns null indicating inability to resolve.
      */
     private function resolveName(string $name) : ?string
     {
@@ -127,7 +116,6 @@ final class StandaloneHydratorPluginManager implements
             return $this->aliases[$name];
         }
 
-        $alias = strtolower($name);
-        return $this->aliases[$alias] ?? null;
+        return $this->aliases[strtolower($name)] ?? null;
     }
 }

--- a/src/StandaloneHydratorPluginManager.php
+++ b/src/StandaloneHydratorPluginManager.php
@@ -67,23 +67,18 @@ final class StandaloneHydratorPluginManager implements
      */
     private $factories = [];
 
-    /**
-     * @var callable Invokable factory for hydrators without dedicated factories.
-     */
-    private $invokableFactory;
-
     public function __construct()
     {
-        $this->invokableFactory = function (ContainerInterface $container, string $class) {
+        $invokableFactory = function (ContainerInterface $container, string $class) {
             return new $class();
         };
 
         $this->factories = [
-            ArraySerializableHydrator::class => $this->invokableFactory,
-            ClassMethodsHydrator::class      => $this->invokableFactory,
+            ArraySerializableHydrator::class => $invokableFactory,
+            ClassMethodsHydrator::class      => $invokableFactory,
             DelegatingHydrator::class        => new DelegatingHydratorFactory(),
-            ObjectPropertyHydrator::class    => $this->invokableFactory,
-            ReflectionHydrator::class        => $this->invokableFactory,
+            ObjectPropertyHydrator::class    => $invokableFactory,
+            ReflectionHydrator::class        => $invokableFactory,
         ];
     }
 

--- a/src/StandaloneHydratorPluginManager.php
+++ b/src/StandaloneHydratorPluginManager.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-hydrator for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-hydrator/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Hydrator;
+
+use Psr\Container\ContainerInterface;
+
+use function strtolower;
+
+/**
+ * Standalone hydrator manager.
+ *
+ * This class implements a standalone version of the HydratorPluginManager
+ * that can be used anywhere a PSR-11 ContainerInterface is expected.
+ *
+ * It will load any hydrator implementation shipped in this package, and only
+ * those hydrators shipped in this package, using:
+ *
+ * - The fully qualified class name.
+ * - The class name minus the namespace.
+ * - The fully qualified class name minus the "Hydrator" suffix (for BC
+ *   compatibility with v2 names).
+ * - The class name minus the namespace or the "Hydrator" suffix (for BC
+ *   compatibility with v2 names).
+ *
+ * If you want to be able to configure additional services, you will need to
+ * either install zend-servicemanager and use the HydratorPluginManager;
+ * wire hydrators into your application container; or write your own
+ * implementation.
+ */
+final class StandaloneHydratorPluginManager implements
+    ContainerInterface,
+    HydratorPluginManagerInterface
+{
+    /**
+     * To allow using the short name (class name without namespace), this maps
+     * the lowercase name to the FQCN. For hydrators that in previous versions
+     * did not have the Hydrator suffix, it also maps the class name without
+     * the suffix.
+     *
+     * @var array<string, string>
+     */
+    private $aliases = [
+        'arrayserializable'         => ArraySerializableHydrator::class,
+        ArraySerializable::class    => ArraySerializableHydrator::class,
+        'arrayserializablehydrator' => ArraySerializableHydrator::class,
+        ClassMethods::class         => ClassMethodsHydrator::class,
+        'classmethods'              => ClassMethodsHydrator::class,
+        'classmethodshydrator'      => ClassMethodsHydrator::class,
+        'delegatinghydrator'        => DelegatingHydrator::class,
+        ObjectProperty::class       => ObjectPropertyHydrator::class,
+        'objectpropertyhydrator'    => ObjectPropertyHydrator::class,
+        'objectproperty'            => ObjectPropertyHydrator::class,
+        Reflection::class           => ReflectionHydrator::class,
+        'reflectionhydrator'        => ReflectionHydrator::class,
+        'reflection'                => ReflectionHydrator::class,
+    ];
+
+    /**
+     * @var array<string, callable>
+     */
+    private $factories = [];
+
+    /**
+     * @var callable Invokable factory for hydrators without dedicated factories.
+     */
+    private $invokableFactory;
+
+    public function __construct()
+    {
+        $this->invokableFactory = function (ContainerInterface $container, string $class) {
+            return new $class();
+        };
+
+        $this->factories = [
+            ArraySerializableHydrator::class => $this->invokableFactory,
+            ClassMethodsHydrator::class      => $this->invokableFactory,
+            DelegatingHydrator::class        => new DelegatingHydratorFactory(),
+            ObjectPropertyHydrator::class    => $this->invokableFactory,
+            ReflectionHydrator::class        => $this->invokableFactory,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get($id)
+    {
+        $class = $this->resolveName($id);
+        if (! $class) {
+            throw Exception\MissingHydratorServiceException::forService($id);
+        }
+
+        $instance = ($this->factories[$class])($this, $class);
+
+        return $instance;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function has($id)
+    {
+        return null !== $this->resolveName($id);
+    }
+
+    /**
+     * Resolve a service name from an identifier.
+     *
+     * If $name is registered in $factories, the method returns it verbatim.
+     *
+     * Next it checks if the $name is registered verbatim in $aliases; if so,
+     * it returns the target of the alias.
+     *
+     * finally, it does a strtolower() on it and looks to see if it exists
+     * in the $aliases array; if so, it returns the target of the alias,
+     * otherwise it returns null indicating inability to resolve.
+     */
+    private function resolveName(string $name) : ?string
+    {
+        if (isset($this->factories[$name])) {
+            return $name;
+        }
+
+        if (isset($this->aliases[$name])) {
+            return $this->aliases[$name];
+        }
+
+        $alias = strtolower($name);
+        return $this->aliases[$alias] ?? null;
+    }
+}

--- a/src/StandaloneHydratorPluginManagerFactory.php
+++ b/src/StandaloneHydratorPluginManagerFactory.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-hydrator for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-hydrator/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Hydrator;
+
+use Psr\Container\ContainerInterface;
+
+final class StandaloneHydratorPluginManagerFactory
+{
+    public function __invoke(ContainerInterface $container) : StandaloneHydratorPluginManager
+    {
+        return new StandaloneHydratorPluginManager();
+    }
+}

--- a/test/StandaloneHydratorPluginManagerFactoryTest.php
+++ b/test/StandaloneHydratorPluginManagerFactoryTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-hydrator for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-hydrator/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Hydrator;
+
+use PHPUnit\Framework\Error\Notice;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Zend\Hydrator\ArraySerializable;
+use Zend\Hydrator\ArraySerializableHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
+use Zend\Hydrator\DelegatingHydrator;
+use Zend\Hydrator\DelegatingHydratorFactory;
+use Zend\Hydrator\ObjectProperty;
+use Zend\Hydrator\ObjectPropertyHydrator;
+use Zend\Hydrator\Reflection;
+use Zend\Hydrator\ReflectionHydrator;
+use Zend\Hydrator\StandaloneHydratorPluginManager;
+use Zend\Hydrator\StandaloneHydratorPluginManagerFactory;
+
+use function sprintf;
+
+class StandaloneHydratorPluginManagerFactoryTest extends TestCase
+{
+    private const MESSAGE_DEFAULT_SERVICES = 'Missing the service %s';
+
+    public function setUp()
+    {
+        $this->factory   = new StandaloneHydratorPluginManagerFactory();
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function assertDefaultServices(
+        StandaloneHydratorPluginManager $manager,
+        string $message = self::MESSAGE_DEFAULT_SERVICES
+    ) {
+        $this->assertTrue($manager->has('ArraySerializable'), sprintf($message, 'ArraySerializable'));
+        $this->assertTrue($manager->has('ArraySerializableHydrator'), sprintf($message, 'ArraySerializableHydrator'));
+        $this->assertTrue($manager->has(ArraySerializable::class), sprintf($message, ArraySerializable::class));
+        $this->assertTrue(
+            $manager->has(ArraySerializableHydrator::class),
+            sprintf($message, ArraySerializableHydrator::class)
+        );
+
+        $this->assertTrue($manager->has('ClassMethods'), sprintf($message, 'ClassMethods'));
+        $this->assertTrue($manager->has('ClassMethodsHydrator'), sprintf($message, 'ClassMethodsHydrator'));
+        $this->assertTrue($manager->has(ClassMethods::class), sprintf($message, ClassMethods::class));
+        $this->assertTrue($manager->has(ClassMethodsHydrator::class), sprintf($message, ClassMethodsHydrator::class));
+
+        $this->assertTrue($manager->has('DelegatingHydrator'), sprintf($message, 'DelegatingHydrator'));
+        $this->assertTrue($manager->has(DelegatingHydrator::class), sprintf($message, DelegatingHydrator::class));
+
+        $this->assertTrue($manager->has('ObjectProperty'), sprintf($message, 'ObjectProperty'));
+        $this->assertTrue($manager->has('ObjectPropertyHydrator'), sprintf($message, 'ObjectPropertyHydrator'));
+        $this->assertTrue($manager->has(ObjectProperty::class), sprintf($message, ObjectProperty::class));
+        $this->assertTrue(
+            $manager->has(ObjectPropertyHydrator::class),
+            sprintf($message, ObjectPropertyHydrator::class)
+        );
+
+        $this->assertTrue($manager->has('Reflection'), sprintf($message, 'Reflection'));
+        $this->assertTrue($manager->has('ReflectionHydrator'), sprintf($message, 'ReflectionHydrator'));
+        $this->assertTrue($manager->has(Reflection::class), sprintf($message, Reflection::class));
+        $this->assertTrue($manager->has(ReflectionHydrator::class), sprintf($message, ReflectionHydrator::class));
+    }
+
+    public function testCreatesPluginManagerWithDefaultServices()
+    {
+        $manager = ($this->factory)($this->container->reveal());
+        $this->assertDefaultServices($manager);
+    }
+}

--- a/test/StandaloneHydratorPluginManagerTest.php
+++ b/test/StandaloneHydratorPluginManagerTest.php
@@ -35,11 +35,6 @@ class StandaloneHydratorPluginManagerTest extends TestCase
         return $r->getValue($class);
     }
 
-    public function testInstantiationInitializesInvokableFactoryProperty()
-    {
-        $this->assertAttributeInstanceOf(Closure::class, 'invokableFactory', $this->manager);
-    }
-
     public function hydratorsWithoutConstructors() : iterable
     {
         yield 'ArraySerializable'               => [Hydrator\ArraySerializableHydrator::class];
@@ -61,11 +56,10 @@ class StandaloneHydratorPluginManagerTest extends TestCase
      */
     public function testInstantiationInitializesFactoriesForHydratorsWithoutConstructorArguments(string $class)
     {
-        $invokableFactory = $this->reflectProperty($this->manager, 'invokableFactory');
-        $factories        = $this->reflectProperty($this->manager, 'factories');
+        $factories = $this->reflectProperty($this->manager, 'factories');
 
         $this->assertArrayHasKey($class, $factories);
-        $this->assertSame($invokableFactory, $factories[$class]);
+        $this->assertInstanceOf(Closure::class, $factories[$class]);
     }
 
     public function testDelegatingHydratorFactoryIsInitialized()

--- a/test/StandaloneHydratorPluginManagerTest.php
+++ b/test/StandaloneHydratorPluginManagerTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-hydrator for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-hydrator/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Hydrator;
+
+use Closure;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Zend\Hydrator;
+use Zend\Hydrator\StandaloneHydratorPluginManager;
+
+use function array_pop;
+use function sprintf;
+
+class StandaloneHydratorPluginManagerTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->manager = new StandaloneHydratorPluginManager();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function reflectProperty(object $class, string $property)
+    {
+        $r = new ReflectionProperty($class, $property);
+        $r->setAccessible(true);
+        return $r->getValue($class);
+    }
+
+    public function testInstantiationInitializesInvokableFactoryProperty()
+    {
+        $this->assertAttributeInstanceOf(Closure::class, 'invokableFactory', $this->manager);
+    }
+
+    public function hydratorsWithoutConstructors() : iterable
+    {
+        yield 'ArraySerializable'               => [Hydrator\ArraySerializableHydrator::class];
+        yield 'ArraySerializableHydrator'       => [Hydrator\ArraySerializableHydrator::class];
+        yield 'ClassMethods'                    => [Hydrator\ClassMethodsHydrator::class];
+        yield 'ClassMethodsHydrator'            => [Hydrator\ClassMethodsHydrator::class];
+        yield Hydrator\ArraySerializable::class => [Hydrator\ArraySerializableHydrator::class];
+        yield Hydrator\ClassMethods::class      => [Hydrator\ClassMethodsHydrator::class];
+        yield Hydrator\ObjectProperty::class    => [Hydrator\ObjectPropertyHydrator::class];
+        yield Hydrator\Reflection::class        => [Hydrator\ReflectionHydrator::class];
+        yield 'ObjectPropertyHydrator'          => [Hydrator\ObjectPropertyHydrator::class];
+        yield 'ObjectProperty'                  => [Hydrator\ObjectPropertyHydrator::class];
+        yield 'ReflectionHydrator'              => [Hydrator\ReflectionHydrator::class];
+        yield 'Reflection'                      => [Hydrator\ReflectionHydrator::class];
+    }
+
+    /**
+     * @dataProvider hydratorsWithoutConstructors
+     */
+    public function testInstantiationInitializesFactoriesForHydratorsWithoutConstructorArguments(string $class)
+    {
+        $invokableFactory = $this->reflectProperty($this->manager, 'invokableFactory');
+        $factories        = $this->reflectProperty($this->manager, 'factories');
+
+        $this->assertArrayHasKey($class, $factories);
+        $this->assertSame($invokableFactory, $factories[$class]);
+    }
+
+    public function testDelegatingHydratorFactoryIsInitialized()
+    {
+        $factories = $this->reflectProperty($this->manager, 'factories');
+        $this->assertInstanceOf(
+            Hydrator\DelegatingHydratorFactory::class,
+            $factories[Hydrator\DelegatingHydrator::class]
+        );
+    }
+
+    public function testHasReturnsFalseForUnknownNames()
+    {
+        $this->assertFalse($this->manager->has('unknown-service-name'));
+    }
+
+    public function knownServices() : iterable
+    {
+        foreach ($this->hydratorsWithoutConstructors() as $key => $data) {
+            $class = array_pop($data);
+            $alias = sprintf('%s alias', $key);
+            $fqcn  = sprintf('%s class', $key);
+
+            yield $alias => [$key, $class];
+            yield $fqcn  => [$class, $class];
+        }
+
+        yield 'DelegatingHydrator alias' => ['DelegatingHydrator', Hydrator\DelegatingHydrator::class];
+        yield 'DelegatingHydrator class' => [Hydrator\DelegatingHydrator::class, Hydrator\DelegatingHydrator::class];
+    }
+
+    /**
+     * @dataProvider knownServices
+     */
+    public function testHasReturnsTrueForKnownServices(string $service)
+    {
+        $this->assertTrue($this->manager->has($service));
+    }
+
+    public function testGetRaisesExceptionForUnknownService()
+    {
+        $this->expectException(Hydrator\Exception\MissingHydratorServiceException::class);
+        $this->manager->get('unknown-service-name');
+    }
+
+    /**
+     * @dataProvider knownServices
+     */
+    public function testGetReturnsExpectedTypesForKnownServices(string $service, string $expectedType)
+    {
+        $instance = $this->manager->get($service);
+        $this->assertInstanceOf($expectedType, $instance);
+    }
+}


### PR DESCRIPTION
This patch allows zend-hydrator to be used without zend-servicemanager, making that package a truly optional dependency.

First, it adds `Zend\Hydrator\HydratorPluginManagerInterface`, which extends the PSR-11 `ContainerInterface`. This is done to ensure that any plugin manager implementation complies with PSR-11 (currently, `AbstractPluginManager` implementations from zend-servicemanager do not), as well as to allow type-hinting on that interface when a plugin manager is needed. The `DelegatingHydratorFactory` was updated to test against this interface instead of the `HydratorPluginManager`.

Next, the patch adds `Zend\Hydrator\StandaloneHydratorPluginManager`, which provides a minimal plugin manager that supports loading *only the shipped hydrator implementations*. A factory for creating the plugin manager is also provided via `Zend\Hydrator\StandaloneHydratorPluginManagerFactory`. 

`Zend\Hydrator\ConfigProvider` was updated to add the `StandaloneHydratorPluginManager` factory mapping, as well as to change the target of the `HydratorManager` alias based on the presence of the zend-servicemanager package.

A page on plugin managers was added, and includes an example of creating a custom plugin manager.

Fixes #72