### PR TITLE
Remove object return typehints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,11 @@ All notable changes to this project will be documented in this file, in reverse 
   When in doubt, use the fully qualified class name, or the class name minus the
   namespace, with correct casing.
 
-- [#80](https://github.com/zendframework/zend-hydrator/pull/80) adds scalar and object typehints, both to parameters and return values, wherever
-  possible. For consumers, this should pose no discernable change. **For those
-  implementing interfaces or extending classes from this package, updates will
-  be necessary to ensure your code will run.** [See the migration guide for
-  details](https://docs.zendframework.com/zend-hydrator/v3/migration/).
+- [#80](https://github.com/zendframework/zend-hydrator/pull/80) adds scalar typehints both to parameters and return values, and object
+  typehints to parameters, wherever possible. For consumers, this should pose no
+  discernable change. **For those implementing interfaces or extending classes
+  from this package, updates will be necessary to ensure your code will run.**
+  [See the migration guide for details](https://docs.zendframework.com/zend-hydrator/v3/migration/).
 
 - [#14](https://github.com/zendframework/zend-hydrator/pull/14) replaces usage of zend-filter with the hardcoded filters referenced in
   the above section.

--- a/docs/book/v3/migration.md
+++ b/docs/book/v3/migration.md
@@ -43,7 +43,7 @@ on parameters and return values. These include:
   - `hasFilter($name)` becomes `hasFilter(string $name) : bool`
   - `removeFilter($name)` becomes `removeFilter(string $name) : void`
 - `Zend\Hydrator\HydrationInterface`:
-  - `hydrate(array $data, $object)` becomes `hydrate(array $data, object $object) : object`
+  - `hydrate(array $data, $object)` becomes `hydrate(array $data, object $object)`
 - `Zend\Hydrator\HydratorAwareInterface`:
   - `setHydrator(Zend\Hydrator\HydratorInterface $hydrator)` becomes `setHydrator(Zend\Hydrator\HydratorInterface $hydrator) : void`
   - `getHydrator()` becomes `getHydrator() : ?Zend\Hydrator\HydratorInterface`

--- a/docs/book/v3/quick-start.md
+++ b/docs/book/v3/quick-start.md
@@ -36,8 +36,11 @@ interface HydrationInterface
      * Hydrate $object with the provided $data.
      *
      * @param mixed[] $data
+     * @return object The implementation should return an object of any type.
+     *     By purposely omitting the return type from the signature,
+     *     implementations may choose to specify a more specific type.
      */
-    public function hydrate(array $data, object $object) : object;
+    public function hydrate(array $data, object $object);
 }
 ```
 

--- a/src/Aggregate/AggregateHydrator.php
+++ b/src/Aggregate/AggregateHydrator.php
@@ -50,7 +50,7 @@ class AggregateHydrator implements HydratorInterface, EventManagerAwareInterface
     /**
      * {@inheritDoc}
      */
-    public function hydrate(array $data, object $object) : object
+    public function hydrate(array $data, object $object)
     {
         $event = new HydrateEvent($this, $object, $data);
         $this->getEventManager()->triggerEvent($event);

--- a/src/ArraySerializable.php
+++ b/src/ArraySerializable.php
@@ -64,7 +64,7 @@ class ArraySerializable extends AbstractHydrator
      * {@inheritDoc}
      * @throws Exception\BadMethodCallException for an $object not implementing exchangeArray() or populate()
      */
-    public function hydrate(array $data, object $object) : object
+    public function hydrate(array $data, object $object)
     {
         $replacement = [];
         foreach ($data as $key => $value) {

--- a/src/ClassMethods.php
+++ b/src/ClassMethods.php
@@ -201,7 +201,7 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
      *
      * {@inheritDoc}
      */
-    public function hydrate(array $data, object $object) : object
+    public function hydrate(array $data, object $object)
     {
         $objectClass = get_class($object);
 

--- a/src/DelegatingHydrator.php
+++ b/src/DelegatingHydrator.php
@@ -28,7 +28,7 @@ class DelegatingHydrator implements HydratorInterface
     /**
      * {@inheritdoc}
      */
-    public function hydrate(array $data, object $object) : object
+    public function hydrate(array $data, object $object)
     {
         return $this->getHydrator($object)->hydrate($data, $object);
     }

--- a/src/HydrationInterface.php
+++ b/src/HydrationInterface.php
@@ -15,6 +15,9 @@ interface HydrationInterface
      * Hydrate $object with the provided $data.
      *
      * @param mixed[] $data
+     * @return object The implementation should return an object of any type.
+     *     By purposely omitting the return type from the signature,
+     *     implementations may choose to specify a more specific type.
      */
-    public function hydrate(array $data, object $object) : object;
+    public function hydrate(array $data, object $object);
 }

--- a/src/ObjectProperty.php
+++ b/src/ObjectProperty.php
@@ -62,7 +62,7 @@ class ObjectProperty extends AbstractHydrator
      *
      * {@inheritDoc}
      */
-    public function hydrate(array $data, object $object) : object
+    public function hydrate(array $data, object $object)
     {
         $properties =& self::$skippedPropertiesCache[get_class($object)] ?? null;
 

--- a/src/Reflection.php
+++ b/src/Reflection.php
@@ -49,7 +49,7 @@ class Reflection extends AbstractHydrator
      *
      * {@inheritDoc}
      */
-    public function hydrate(array $data, object $object) : object
+    public function hydrate(array $data, object $object)
     {
         $reflProperties = self::getReflProperties($object);
         foreach ($data as $key => $value) {


### PR DESCRIPTION
Previously, #80 added typehints everywhere, including `object` return typehints. However, there are use cases for allowing implementations to specify a more specific value: when a specific hydrator is in use, you know you are then guaranteed an object of the specified type when you call `hydrate()`.

As such, this patch removes the `object` return typehint from the `HydrationInterface::hydrate()` method, and all implementations.

> Note: It _does not_ remove the `object` typehint from the `HydratorListener::onHydrate()`, `HydrateEvent::getHydrationObject()`, or `ExtractEvent::getExtractionObject()`, as these will not generally be consumed directly by users, and the more specific return typehint gives us type safety here.