### PR TITLE
Cast keys to string on getting data from object

### DIFF
--- a/src/ArraySerializableHydrator.php
+++ b/src/ArraySerializableHydrator.php
@@ -36,6 +36,8 @@ class ArraySerializableHydrator extends AbstractHydrator
         $filter = $this->getFilter();
 
         foreach ($data as $name => $value) {
+            $name = (string) $name;
+
             if (! $filter->filter($name)) {
                 unset($data[$name]);
                 continue;

--- a/test/ArraySerializableHydratorTest.php
+++ b/test/ArraySerializableHydratorTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace ZendTest\Hydrator;
 
+use ArrayObject;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 use Zend\Hydrator\ArraySerializableHydrator;
@@ -168,5 +169,18 @@ class ArraySerializableHydratorTest extends TestCase
         $final = $original->getArrayCopy();
 
         $this->assertSame($expected, $final['tags']);
+    }
+
+    public function testExtractArrayObject()
+    {
+        $arrayObject = new ArrayObject([
+            'value1',
+            'value2',
+            'value3',
+        ]);
+
+        $data = $this->hydrator->extract($arrayObject);
+
+        $this->assertSame(['value1', 'value2', 'value3'], $data);
     }
 }


### PR DESCRIPTION
Fixes:
- https://github.com/zfcampus/zf-apigility-admin/issues/397
- https://github.com/zfcampus/zf-apigility-admin-ui/issues/149

When extracting data from ArrayObject or another object which int keys we are getting the following error:

```
Argument 1 passed to Zend\Hydrator\Filter\FilterComposite::filter() must be of the type string, integer given, called in vendor/zendframework/zend-hydrator/src/ArraySerializableHydrator.php on line 39
```

as we have strict type declaration.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.