### PR TITLE
Fixed static on MapMapping asymmetric method and its misspell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#97](https://github.com/zendframework/zend-hydrator/pull/97) adds missing `static` keyword to `Zend\Hydrator\NamingStrategy\MapNamingStrategy::createFromAsymmetricMap` while fixing misspelling.
 
 ## 3.0.0 - 2018-12-10
 

--- a/docs/book/v3/migration.md
+++ b/docs/book/v3/migration.md
@@ -207,7 +207,7 @@ three "named constructors":
 ```php
 public static function createFromExtractionMap(array $extractionMap) : MapNamingStrategy;
 public static function createFromHydrationMap(array $hydrationMap) : MapNamingStrategy;
-public static function createFromAssymetricMap(array $extractionMap, array $hydrationMap) : MapNamingStrategy;
+public static function createFromAsymmetricMap(array $extractionMap, array $hydrationMap) : MapNamingStrategy;
 ```
 
 In the first two cases, the constructor will flip the arrays for purposes of the

--- a/docs/book/v3/naming-strategy/map-naming-strategy.md
+++ b/docs/book/v3/naming-strategy/map-naming-strategy.md
@@ -17,7 +17,7 @@ based on the direction:
 - When maps are provided for both extraction and hydration, the appropriate map
   will be used during extraction and hydration operations. You can create an
   instance with this behavior using
-  `MapNamingStrategy::createFromAssymetricMap(array $extractionMap, array $hydrationStrategy) : MapNamingStrategy`.
+  `MapNamingStrategy::createFromAsymmetricMap(array $extractionMap, array $hydrationStrategy) : MapNamingStrategy`.
 
 Most of the time, you will want your maps symmetrical; as such, set either a
 hydration map or an extraction map, but not both.
@@ -60,7 +60,7 @@ echo $namingStrategy->hydrate('bash'); // outputs: baz
 ### Both hydration and extraction maps
 
 ```php
-$namingStrategy = Zend\Hydrator\NamingStrategy\MapNamingStrategy::createFromAssymetricMap(
+$namingStrategy = Zend\Hydrator\NamingStrategy\MapNamingStrategy::createFromAsymmetricMap(
     [
         'foo' => 'bar',
         'baz' => 'bash'

--- a/src/NamingStrategy/MapNamingStrategy.php
+++ b/src/NamingStrategy/MapNamingStrategy.php
@@ -52,19 +52,6 @@ final class MapNamingStrategy implements NamingStrategyInterface
     /**
      * @param array<string, string> $extractionMap
      * @param array<string, string> $hydrationMap
-     * @deprecated Use createFromAsymmetricMap
-     */
-    public static function createFromAssymetricMap(array $extractionMap, array $hydrationMap) : self
-    {
-        $strategy = new self();
-        $strategy->extractionMap = $extractionMap;
-        $strategy->hydrationMap  = $hydrationMap;
-        return $strategy;
-    }
-
-    /**
-     * @param array<string, string> $extractionMap
-     * @param array<string, string> $hydrationMap
      */
     public static function createFromAsymmetricMap(array $extractionMap, array $hydrationMap) : self
     {

--- a/src/NamingStrategy/MapNamingStrategy.php
+++ b/src/NamingStrategy/MapNamingStrategy.php
@@ -52,8 +52,21 @@ final class MapNamingStrategy implements NamingStrategyInterface
     /**
      * @param array<string, string> $extractionMap
      * @param array<string, string> $hydrationMap
+     * @deprecated Use createFromAsymmetricMap
      */
-    public function createFromAssymetricMap(array $extractionMap, array $hydrationMap) : self
+    public static function createFromAssymetricMap(array $extractionMap, array $hydrationMap) : self
+    {
+        $strategy = new self();
+        $strategy->extractionMap = $extractionMap;
+        $strategy->hydrationMap  = $hydrationMap;
+        return $strategy;
+    }
+
+    /**
+     * @param array<string, string> $extractionMap
+     * @param array<string, string> $hydrationMap
+     */
+    public static function createFromAsymmetricMap(array $extractionMap, array $hydrationMap) : self
     {
         $strategy = new self();
         $strategy->extractionMap = $extractionMap;
@@ -84,7 +97,7 @@ final class MapNamingStrategy implements NamingStrategyInterface
      *
      * - createFromExtractionMap()
      * - createFromHydrationMap()
-     * - createFromAssymetricMap()
+     * - createFromAsymmetricMap()
      */
     private function __construct()
     {

--- a/test/NamingStrategy/MapNamingStrategyTest.php
+++ b/test/NamingStrategy/MapNamingStrategyTest.php
@@ -124,4 +124,11 @@ class MapNamingStrategyTest extends TestCase
         $strategy = MapNamingStrategy::createFromExtractionMap(['foo' => 'bar']);
         $this->assertEquals('foo', $strategy->hydrate('bar'));
     }
+
+    public function testHydrateAndExtractUseAsymmetricMapProvided()
+    {
+        $strategy = MapNamingStrategy::createFromAsymmetricMap(['foo' => 'bar'], ['bat' => 'baz']);
+        $this->assertEquals('bar', $strategy->extract('foo'));
+        $this->assertEquals('baz', $strategy->hydrate('bat'));
+    }
 }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

`Zend\Hydrator\NamingStrategy\MapNamingStrategy::createFromAssymetricMap` is not static, as [documentation](https://docs.zendframework.com/zend-hydrator/v3/naming-strategy/map-naming-strategy/#both-hydration-and-extraction-maps) mentions. Moreover, its constructor is private, so the method cannot be accessed from an instance.

This PR adds the `static` keyword to the `createFromAssymetricMap` method, and duplicates it to fix a misspelling, while avoiding BC break.