### PR TITLE
Bug in Underscore Namingstrategy

### DIFF
--- a/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
@@ -104,6 +104,10 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
                 'one2THR23ree',
                 'one_2_thr_23_ree'
             ],
+            'lowercased alphanumeric' => [
+                'bfd7b82e9cfceaa82704d1c1Foo',
+                'bfd7b82e9cfceaa82704d1c1_foo',
+            ],
         ];
     }
 


### PR DESCRIPTION
Hey guys,

in v2, the failing unit test worked as expected.
Since v3, the `CamelCaseToUnderscoreFilter` adds various underscores around the numeric values within a string.

Any suggestion how this can be fixed without breaking the other tests?

And why was that behavior changed that much?
`CamelCaseToSeparator` of `zend-filter` works a lot different than the new logic.

I dont even get the new logic:
```
-'bfd7b82e9cfceaa82704d1c1_foo'
+'bfd_7_b82e_9_cfceaa_82704_d1c_1_foo'
```

So why the string is being separated with `_` after `bfd` and not after `bfd7b` again? x_O