### PR TITLE
Restore original behavior of UnderscoreNamingStrategy

### DIFF
--- a/src/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilter.php
+++ b/src/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilter.php
@@ -39,24 +39,20 @@ final class CamelCaseToUnderscoreFilter
         return $this->hasPcreUnicodeSupport()
             ? [
                 [ // pattern
-                    '#(\p{L})(\p{Nd}+)(\p{L})#',
                     '#(?<=(?:\p{Lu}))(\p{Lu}\p{Ll})#',
                     '#(?<=(?:\p{Ll}|\p{Nd}))(\p{Lu})#',
                 ],
                 [ // replacement
-                    '\1_\2_\3',
                     '_\1',
                     '_\1',
                 ],
             ]
             : [
                 [ // pattern
-                    '#([A-Za-z])([0-9]+)([A-Za-z])#',
                     '#(?<=(?:[A-Z]))([A-Z]+)([A-Z][a-z])#',
                     '#(?<=(?:[a-z0-9]))([A-Z])#',
                 ],
                 [ // replacement
-                    '\1_\2_\3',
                     '\1_\2',
                     '_\1',
                 ],

--- a/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
@@ -94,7 +94,7 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
             ],
             'alphanumeric' => [
                 'one2Three',
-                'one_2_three'
+                'one2_three'
             ],
             'multiple uppercased letters and underscores' => [
                 'TheseAre_SOME_CamelCASEDWords',
@@ -102,7 +102,7 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
             ],
             'alphanumeric multiple up cases' => [
                 'one2THR23ree',
-                'one_2_thr_23_ree'
+                'one2_thr23ree'
             ],
             'lowercased alphanumeric' => [
                 'bfd7b82e9cfceaa82704d1c1Foo',
@@ -124,7 +124,7 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
             ],
             'alphanumeric' => [
                 'one2Three',
-                'one_2_three'
+                'one2_three'
             ],
             'multiple uppercased letters and underscores' => [
                 'TheseAre_SOME_CamelCASEDWords',
@@ -132,7 +132,7 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
             ],
             'alphanumeric multiple up cases' => [
                 'one2THR23ree',
-                'one_2_thr_23_ree'
+                'one2_thr23ree'
             ],
             'unicode' => [
                 'testŠuma',
@@ -154,7 +154,7 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
             ],
             'alphanumeric' => [
                 'one2Three',
-                'one_2_three'
+                'one2_three'
             ],
             'multiple uppercased letters and underscores' => [
                 'TheseAre_SOME_CamelCASEDWords',
@@ -162,7 +162,7 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
             ],
             'alphanumeric multiple up cases' => [
                 'one2THR23ree',
-                'one_2_thr_23_ree'
+                'one2_thr23ree'
             ],
             'unicode uppercase character' => [
                 'testŠuma',

--- a/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
@@ -104,6 +104,10 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
                 'one2THR23ree',
                 'one_2_thr_23_ree'
             ],
+            'lowercased alphanumeric' => [
+                'bfd7b82e9cfceaa82704d1c1Foo',
+                'bfd7b82e9cfceaa82704d1c1_foo',
+            ],
         ];
     }
 

--- a/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
@@ -53,8 +53,12 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
                 'studly_cases_me',
                 'studlyCasesMe'
             ],
-            'alphanumeric' => [
+            'alphanumeric in single word' => [
                 'one_2_three',
+                'one2Three'
+            ],
+            'alphanumeric in separate words' => [
+                'one2_three',
                 'one2Three'
             ],
         ];
@@ -89,8 +93,12 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
                 'studly_cases_me',
                 'studlyCasesMe'
             ],
-            'alphanumeric' => [
+            'alphanumeric in single word' => [
                 'one_2_three',
+                'one2Three'
+            ],
+            'alphanumeric in separate words' => [
+                'one2_three',
                 'one2Three'
             ],
             'unicode character' => [
@@ -132,8 +140,12 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
                 'studly_cases_me',
                 'studlyCasesMe'
             ],
-            'alphanumeric' => [
+            'alphanumeric in single word' => [
                 'one_2_three',
+                'one2Three'
+            ],
+            'alphanumeric in separate words' => [
+                'one2_three',
                 'one2Three'
             ],
             'uppercase unicode character' => [


### PR DESCRIPTION
Patch #14 inlined the `CamelCaseToUnderscore` and `UnderscoreToCamelCase` filters in the package. However, in doing so, it added behavior that was not expected, nor present in the original: splitting words on numeric boundaries.

Furthermore, the functionality was unpredictable; some boundaries were matched, while others were not, which led to an inability to predict what would happen.

The problem stemmed from the addition of a regex in each of the unicode and non-unicode matching pattern sets, as well as corresponding replacement sets. These have been reverted to match those in zend-filter, which restores behavior to how it worked in version 2.

Additional test cases were provided to the `UnderscoreToCamelCaseTest` to demonstrate the reverse operations as well. One note: when converting from underscore to camel case and word splits happen before numeric values, there is no way to guarantee the opposite operation (camel case to underscore) will resolve to the original value. If such input is expected, it should likely use a custom filter.

Replaces #101